### PR TITLE
[Breaking] Change validator function signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ export default Controller.extend({
       return changeset.rollback();
     },
 
-    validate(key, newValue, oldValue) {
+    validate({ key, newValue, oldValue, changes }) {
       // lookup a validator function on your favorite validation library
       // should return a Boolean
     }
@@ -388,7 +388,7 @@ const { Controller } = Ember;
 
 export default Controller.extend({
   actions: {
-    validate(key, newValue, oldValue, changes) {
+    validate({ key, newValue, oldValue, changes }) {
       // lookup a validator function on your favorite validation library
       // should return a Boolean
     }
@@ -401,7 +401,7 @@ export default Controller.extend({
 {{dummy-form changeset=(changeset model (action "validate"))}}
 ```
 
-Your action will receive the `key`, `newValue`, `oldValue` and a one way reference to `changes`.
+Your action will receive a single POJO containing the `key`, `newValue`, `oldValue` and a one way reference to `changes`.
 
 ## Installation
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -270,7 +270,12 @@ export function changeset(obj, validateFn, validationMap) {
       let validator = get(this, VALIDATOR);
 
       if (typeOf(validator) === 'function') {
-        let isValid = validator(key, newValue, oldValue, pureAssign(changes));
+        let isValid = validator({
+          key,
+          newValue,
+          oldValue,
+          changes: pureAssign(changes)
+        });
 
         return isPresent(isValid) ? isValid : true;
       }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -22,11 +22,11 @@ export default Controller.extend({
       return changeset.rollback();
     },
 
-    validate(key, newValue, oldValue) {
+    validate({ key, newValue, oldValue, changes }) {
       let validatorFn = validations[key];
 
       if (typeOf(validatorFn) === 'function') {
-        return validatorFn(newValue, oldValue);
+        return validatorFn(newValue, oldValue, changes);
       }
     }
   }

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -27,7 +27,7 @@ let dummyValidations = {
     return resolve(value);
   }
 };
-function dummyValidator(key, newValue, oldValue, changes) {
+function dummyValidator({ key, newValue, oldValue, changes }) {
   let validatorFn = dummyValidations[key];
 
   if (typeOf(validatorFn) === 'function') {


### PR DESCRIPTION
The validator function now receives 1 argument: `{ key, newValue, oldValue, changes }`
instead of 4.