### PR TITLE
Proxy `get` to change or content

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,10 +264,12 @@ get(changeset, 'isDirty'); // true
 
 #### `get`
 
-Exactly the same semantics as `Ember.get`. This proxies to the underlying Object.
+Exactly the same semantics as `Ember.get`. This proxies to the underlying Object, or the changed value if present.
 
 ```js
 get(changeset, 'firstName'); // "Jim"
+set(changeset, 'firstName', 'Billy'); // "Billy"
+get(changeset, 'firstName'); // "Billy"
 ```
 
 You can use and bind this property in the template:

--- a/addon/index.js
+++ b/addon/index.js
@@ -76,15 +76,19 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     },
 
     /**
-     * Proxies `get` to the underlying content.
+     * Proxies `get` to the underlying content or changed value, if present.
      *
      * @public
      * @param  {String} key
      * @return {Any}
      */
     unknownProperty(key) {
+      let changes = get(this, CHANGES);
       let content = get(this, CONTENT);
-      return get(content, key);
+      let changedValue = get(changes, key);
+      let originalValue = get(content, key);
+
+      return isPresent(changedValue) ? changedValue : originalValue;
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.5.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -54,6 +54,15 @@ test('#get proxies to content', function(assert) {
   assert.equal(result, 'Jim Bob', 'should proxy to content');
 });
 
+test('#get returns change if present', function(assert) {
+  set(dummyModel, 'name', 'Jim Bob');
+  let dummyChangeset = new Changeset(dummyModel);
+  set(dummyChangeset, 'name', 'Milton Waddams');
+  let result = get(dummyChangeset, 'name');
+
+  assert.equal(result, 'Milton Waddams', 'should proxy to change');
+});
+
 test('#set adds a change if valid', function(assert) {
   let expectedChanges = [{ key: 'name', value: 'foo' }];
   let dummyChangeset = new Changeset(dummyModel);


### PR DESCRIPTION
If present, `#get` will attempt to fetch the value from the changeset's
internal list of changes. Otherwise, it fallsback to the underlying
content's value for that key.