### PR TITLE
Fix for isValid property not updating after a change

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -327,10 +327,12 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
       }
 
       this._deleteKey(CHANGES, key);
+      set(errors, key, options);
+      
       this.notifyPropertyChange(ERRORS);
       this.notifyPropertyChange(key);
 
-      return set(errors, key, options);
+      return options;
     },
 
     /**


### PR DESCRIPTION
Error changes are notified before the _errors object is changed. This caused the isValid property to lag