### PR TITLE
Creating a model on execute and stacked changesets

### DIFF
--- a/tests/unit/changeset-newedmodel-test.js
+++ b/tests/unit/changeset-newedmodel-test.js
@@ -1,0 +1,667 @@
+import Ember from 'ember';
+import Changeset, {NewEDModel} from 'ember-changeset';
+//import NewEdModel from 'ember-changeset/new-ed-model';
+import { module, test } from 'qunit';
+
+const {
+  Object: EmberObject,
+  RSVP: { resolve, Promise },
+  String: { dasherize },
+  run,
+  get,
+  isPresent,
+  set,
+  typeOf
+} = Ember;
+
+const {
+  next
+} = run;
+
+let dummyModel;
+let dummyValidations = {
+  name(value) {
+    return isPresent(value) && value.length > 3 || 'too short';
+  },
+  password(value) {
+    return value || ['foo', 'bar'];
+  },
+  passwordConfirmation(newValue, _oldValue, { password: changedPassword }, { password }) {
+    return isPresent(newValue) && (changedPassword === newValue || password === newValue) || "password doesn't match";
+  },
+  async(value) {
+    return resolve(value);
+  },
+  options(value) {
+    return isPresent(value);
+  }
+};
+
+function dummyValidator({ key, newValue, oldValue, changes, content }) {
+  let validatorFn = dummyValidations[key];
+
+  if (typeOf(validatorFn) === 'function') {
+    return validatorFn(newValue, oldValue, changes, content);
+  }
+}
+
+module('Unit | Utility | changeset New ED Model', {
+  beforeEach() {
+    let Dummy = EmberObject.extend({
+      save() {
+        return resolve(this);
+      }
+    });
+    let Store = EmberObject.extend({
+      createRecord() {
+        return Dummy.create();
+      }
+    });
+    dummyModel = new NewEDModel("bla", Store.create());
+  }
+});
+
+// Methods
+test('#get proxies to content', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  let result = get(dummyChangeset, 'name');
+
+  assert.equal(result, null, 'should proxy to content');
+});
+
+test('#get returns change if present', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  set(dummyChangeset, 'name', 'Milton Waddams');
+  let result = get(dummyChangeset, 'name');
+
+  assert.equal(result, 'Milton Waddams', 'should proxy to change');
+});
+
+test('#get returns change that is a blank value', function(assert) {
+  set(dummyModel, 'name', 'Jim Bob');
+  let dummyChangeset = new Changeset(dummyModel);
+  set(dummyChangeset, 'name', '');
+  let result = get(dummyChangeset, 'name');
+
+  assert.equal(result, '', 'should proxy to change');
+});
+
+test('#set adds a change if valid', function(assert) {
+  let expectedChanges = [{ key: 'name', value: 'foo' }];
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('name', 'foo');
+  let changes = get(dummyChangeset, 'changes');
+
+  assert.deepEqual(changes, expectedChanges, 'should add change');
+});
+
+test('#set does not add a change if invalid', function(assert) {
+  let expectedErrors = [
+    { key: 'name', validation: 'too short', value: 'a' },
+    { key: 'password', validation: ['foo', 'bar'], value: false }
+  ];
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'a');
+  dummyChangeset.set('password', false);
+  let changes = get(dummyChangeset, 'changes');
+  let errors = get(dummyChangeset, 'errors');
+  let isValid = get(dummyChangeset, 'isValid');
+  let isInvalid = get(dummyChangeset, 'isInvalid');
+
+  assert.deepEqual(changes, [], 'should not add change');
+  assert.deepEqual(errors, expectedErrors, 'should have errors');
+  assert.notOk(isValid, 'should not be valid');
+  assert.ok(isInvalid, 'should be invalid');
+});
+
+test('#prepare provides callback to modify changes', function(assert) {
+  let date = new Date();
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('first_name', 'foo');
+  dummyChangeset.set('date_of_birth', date);
+  dummyChangeset.prepare((changes) => {
+    let modified = {};
+
+    for (let key in changes) {
+      modified[dasherize(key)] = changes[key];
+    }
+
+    return modified;
+  });
+  let changeKeys = get(dummyChangeset, 'changes').map((change) => get(change, 'key'));
+
+  assert.deepEqual(changeKeys, ['first-name', 'date-of-birth'], 'should update changes');
+  dummyChangeset.execute();
+  assert.equal(get(dummyChangeset, 'content.first-name'), 'foo', 'should update changes');
+  assert.equal(get(dummyChangeset, 'content.date-of-birth'), date, 'should update changes');
+});
+
+test('#prepare throws if callback does not return object', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('first_name', 'foo');
+
+  assert.throws(() => dummyChangeset.prepare(() => { return 'foo'; }), ({ message }) => {
+    return message === 'Assertion Failed: Callback to `changeset.prepare` must return an object';
+  }, 'should throw error');
+});
+
+test('#execute applies changes to content if valid', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('name', 'foo');
+
+  assert.equal(get(dummyChangeset, 'content.name'), undefined, 'precondition');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+  dummyChangeset.execute();
+  assert.equal(get(dummyChangeset, 'content.name'), 'foo', 'should apply changes');
+});
+
+test('#execute does not apply changes to content if invalid', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'a');
+
+  assert.equal(get(dummyChangeset, 'content.name'), undefined, 'precondition');
+  assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+  dummyChangeset.execute();
+  assert.equal(get(dummyChangeset, 'content.name'), undefined, 'should not apply changes');
+});
+
+test('#save proxies to content', function(assert) {
+  let result;
+  let options;
+  set(dummyModel, 'save', (dummyOptions) => {
+    result = 'ok';
+    options = dummyOptions;
+    return resolve('saveResult');
+  });
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('name', 'foo');
+
+  assert.equal(result, undefined, 'precondition');
+  let promise = dummyChangeset.save('test options');
+  assert.equal(result, 'ok', 'should save');
+  assert.equal(options, 'test options', 'should proxy options when saving');
+  assert.ok(!!promise && typeof promise.then === 'function', 'save returns a promise');
+  promise.then((saveResult) => {
+    assert.equal(saveResult, 'saveResult', 'save proxies to save promise of content');
+  });
+});
+
+test('#save handles rejected proxy content', function(assert) {
+  let done = assert.async();
+  let dummyChangeset = new Changeset(dummyModel);
+
+  assert.expect(1);
+
+  set(dummyModel, 'save', () => {
+    return new Promise((resolve, reject) => {
+      next(null, reject, new Error('some ember data error'));
+    });
+  });
+
+  run(() => {
+    dummyChangeset.save().catch((error) => {
+        assert.equal(error.message, 'some ember data error');
+      })
+      .finally(() => done());
+  });
+});
+
+test('#save proxies to content even if it does not implement #save', function(assert) {
+  let done = assert.async();
+  let person = { name: 'Jim' };
+  let dummyChangeset = new Changeset(person);
+  dummyChangeset.set('name', 'foo');
+
+  return dummyChangeset.save().then(() => {
+    assert.equal(get(person, 'name'), 'foo', 'persist changes to content');
+    done();
+  });
+});
+
+test('#rollback restores old values', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  let expectedChanges = [
+    { key: 'firstName', value: 'foo' },
+    { key: 'lastName', value: 'bar' }
+  ];
+  let expectedErrors = [{ key: 'name', validation: 'too short', value: '' }];
+  dummyChangeset.set('firstName', 'foo');
+  dummyChangeset.set('lastName', 'bar');
+  dummyChangeset.set('name', '');
+
+  assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'precondition');
+  assert.deepEqual(get(dummyChangeset, 'errors'), expectedErrors, 'precondition');
+  dummyChangeset.rollback();
+  assert.deepEqual(get(dummyChangeset, 'changes'), [], 'should rollback');
+  assert.deepEqual(get(dummyChangeset, 'errors'), [], 'should rollback');
+});
+
+test('#rollback resets valid state', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'a');
+
+  assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+  dummyChangeset.rollback();
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+});
+
+test('#error returns the error object', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  let expectedResult = { name: { validation: 'too short', value: 'a' } };
+  dummyChangeset.set('name', 'a');
+
+  assert.deepEqual(get(dummyChangeset, 'error'), expectedResult, 'should return error object');
+});
+
+test('#change returns the changes object', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  let expectedResult = { name: 'a' };
+  dummyChangeset.set('name', 'a');
+
+  assert.deepEqual(get(dummyChangeset, 'change'), expectedResult, 'should return changes object');
+});
+
+test('#merge merges 2 valid changesets', function(assert) {
+  let dummyChangesetA = new Changeset(dummyModel);
+  let dummyChangesetB = new Changeset(dummyModel);
+  dummyChangesetA.set('firstName', 'Jim');
+  dummyChangesetB.set('lastName', 'Bob');
+  let dummyChangesetC = dummyChangesetA.merge(dummyChangesetB);
+  let expectedChanges = [{ key: 'firstName', value: 'Jim' }, { key: 'lastName', value: 'Bob' }];
+
+  assert.deepEqual(get(dummyChangesetC, 'changes'), expectedChanges, 'should merge 2 valid changesets');
+  assert.deepEqual(get(dummyChangesetA, 'changes'), [{ key: 'firstName', value: 'Jim' }], 'should not mutate first changeset');
+  assert.deepEqual(get(dummyChangesetB, 'changes'), [{ key: 'lastName', value: 'Bob' }], 'should not mutate second changeset');
+});
+
+test('#merge merges invalid changesets', function(assert) {
+  let dummyChangesetA = new Changeset(dummyModel, dummyValidator);
+  let dummyChangesetB = new Changeset(dummyModel, dummyValidator);
+  let dummyChangesetC = new Changeset(dummyModel, dummyValidator);
+  dummyChangesetA.set('age', 21);
+  dummyChangesetA.set('name', 'a');
+  dummyChangesetB.set('name', 'Tony Stark');
+  dummyChangesetC.set('name', 'b');
+
+  let dummyChangesetD = dummyChangesetA.merge(dummyChangesetB);
+  dummyChangesetD = dummyChangesetD.merge(dummyChangesetC);
+
+  let expectedChanges = [{ key: 'age', value: 21 }];
+  let expectedErrors = [{ key: 'name', 'validation': 'too short', value: 'b' }];
+
+  assert.deepEqual(get(dummyChangesetA, 'isInvalid'), true, 'changesetA is not valid becuase of name');
+  assert.deepEqual(get(dummyChangesetB, 'isValid'), true, 'changesetB should be invalid');
+  assert.deepEqual(get(dummyChangesetC, 'isInvalid'), true, 'changesetC should be invalid');
+  assert.deepEqual(get(dummyChangesetD, 'isInvalid'), true, 'changesetD should be invalid');
+  assert.deepEqual(get(dummyChangesetD, 'changes'), expectedChanges, 'should not merge invalid changes');
+  assert.deepEqual(get(dummyChangesetD, 'errors'), expectedErrors, 'should assign errors from both changesets');
+});
+
+test('#merge does not merge a changeset with a non-changeset', function(assert) {
+  let dummyChangesetA = new Changeset(dummyModel, dummyValidator);
+  let dummyChangesetB = { _changes: { name: 'b' } };
+  dummyChangesetA.set('name', 'a');
+
+  assert.throws(() => dummyChangesetA.merge(dummyChangesetB), ({ message }) => {
+    return message === 'Assertion Failed: Cannot merge with a non-changeset';
+  }, 'should throw error');
+});
+
+test('#merge does not merge a changeset with different content', function(assert) {
+  let dummyChangesetA = new Changeset(dummyModel, dummyValidator);
+  let dummyChangesetB = new Changeset(EmberObject.create(), dummyValidator);
+
+  assert.throws(() => dummyChangesetA.merge(dummyChangesetB), ({ message }) => {
+    return message === 'Assertion Failed: Cannot merge with a changeset of different content';
+  }, 'should throw error');
+});
+
+test('#merge preserves content and validator of origin changeset', function(assert) {
+  let dummyChangesetA = new Changeset(dummyModel, dummyValidator);
+  let dummyChangesetB = new Changeset(dummyModel);
+  let dummyChangesetC = dummyChangesetA.merge(dummyChangesetB);
+  let expectedErrors = [{ key: 'name', validation: 'too short', value: 'a' }];
+
+  dummyChangesetC.set('name', 'a');
+  assert.deepEqual(dummyChangesetC.get('errors'), expectedErrors, 'should preserve validator');
+
+  run(() => {
+    dummyChangesetC.set('name', 'Jim Bob');
+    dummyChangesetC.save().then(() => {
+      assert.equal(get(dummyChangesetC, 'content.name'), 'Jim Bob', 'should set value on model');
+    });
+  });
+});
+
+test('#validate/0 validates all fields immediately', function(assert) {
+  let done = assert.async();
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+
+  run(() => {
+    dummyChangeset.validate().then(() => {
+      assert.deepEqual(get(dummyChangeset, 'error.password'), { validation: ['foo', 'bar'], value: null }, 'should validate immediately');
+      assert.deepEqual(get(dummyChangeset, 'changes'), [], 'should not set changes');
+      assert.equal(get(dummyChangeset, 'errors.length'), 5, 'should have 5 errors');
+      done();
+    });
+  });
+});
+
+test('#validate/1 validates a single field immediately', function(assert) {
+  let done = assert.async();
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+
+  run(() => {
+    dummyChangeset.validate('name').then(() => {
+      assert.deepEqual(get(dummyChangeset, 'error.name'), { validation: 'too short', value: null }, 'should validate immediately');
+      assert.deepEqual(get(dummyChangeset, 'changes'), [], 'should not set changes');
+      assert.equal(get(dummyChangeset, 'errors.length'), 1, 'should only have 1 error');
+      done();
+    });
+  });
+});
+
+test('#validate works correctly with changeset values', function(assert) {
+  let done = assert.async();
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+  run(() => {
+    dummyChangeset.validate().then(() => {
+      assert.equal(get(dummyChangeset, 'errors.length'), 5, 'should have 5 error');
+      assert.equal(get(dummyChangeset, 'errors.0.key'), 'name');
+      assert.equal(get(dummyChangeset, 'errors.1.key'), 'password');
+      assert.equal(get(dummyChangeset, 'errors.2.key'), 'passwordConfirmation');
+      assert.equal(get(dummyChangeset, 'errors.3.key'), 'options');
+      assert.equal(get(dummyChangeset, 'errors.4.key'), 'async');
+      assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+    });
+  });
+
+  run(() => {
+    dummyChangeset.set('name', 'Jim Bob');
+    dummyChangeset.validate().then(() => {
+      assert.equal(get(dummyChangeset, 'errors.length'), 4, 'should have 4 error');
+      assert.equal(get(dummyChangeset, 'errors.0.key'), 'password');
+      assert.equal(get(dummyChangeset, 'errors.1.key'), 'passwordConfirmation');
+      assert.equal(get(dummyChangeset, 'errors.2.key'), 'options');
+      assert.equal(get(dummyChangeset, 'errors.3.key'), 'async');
+      assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+    });
+  });
+
+  run(() => {
+    dummyChangeset.set('password', true);
+    dummyChangeset.validate().then(() => {
+      assert.equal(get(dummyChangeset, 'errors.length'), 3, 'should have 3 errors');
+      assert.equal(get(dummyChangeset, 'errors.0.key'), 'passwordConfirmation');
+      assert.equal(get(dummyChangeset, 'errors.1.key'), 'options');
+      assert.equal(get(dummyChangeset, 'errors.2.key'), 'async');
+      assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+    });
+  });
+
+  run(() => {
+    dummyChangeset.set('passwordConfirmation', true);
+    dummyChangeset.validate().then(() => {
+      assert.equal(get(dummyChangeset, 'errors.length'), 2, 'should have 2 errors');
+      assert.equal(get(dummyChangeset, 'errors.0.key'), 'options');
+      assert.equal(get(dummyChangeset, 'errors.1.key'), 'async');
+      assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+    });
+  });
+
+  run(() => {
+    dummyChangeset.set('options', {});
+    dummyChangeset.validate().then(() => {
+      assert.equal(get(dummyChangeset, 'errors.length'), 1, 'should have 1 error');
+      assert.equal(get(dummyChangeset, 'errors.0.key'), 'async');
+      assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+    });
+  });
+
+
+  run(() => {dummyChangeset.set('async', true);});
+  run(() => {
+    dummyChangeset.validate().then(() => {
+      assert.equal(get(dummyChangeset, 'errors.length'), 0, 'should have no errors');
+      assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+      done();
+    });
+  });
+});
+
+test('#validate works correctly with complex values', function(assert) {
+  let done = assert.async();
+  dummyModel.setProperties({});
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+
+  run(() => {
+    dummyChangeset.set('options', { persist: true });
+    dummyChangeset.validate().then(() => {
+      assert.deepEqual(get(dummyChangeset, 'changes.0'), { key: 'options', value: { persist: true }});
+      done();
+    });
+  });
+});
+
+test('#validate marks actual valid changes', function(assert) {
+  let done = assert.async();
+  dummyModel.setProperties({ name: 'Jim Bob', password: true, passwordConfirmation: true, async: true });
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+
+  dummyChangeset.set('name', 'foo bar');
+  dummyChangeset.set('password', false);
+
+  run(() => {
+    dummyChangeset.validate().then(() => {
+      assert.deepEqual(get(dummyChangeset, 'changes'), [{ key: 'name', value: 'foo bar' }]);
+      done();
+    });
+  });
+});
+
+test('#addError adds an error to the changeset', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.addError('email', {
+    value: 'jim@bob.com',
+    validation: 'Email already taken'
+  });
+
+  assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+  assert.equal(get(dummyChangeset, 'error.email.validation'), 'Email already taken', 'should add the error');
+  dummyChangeset.set('email', 'unique@email.com');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+});
+
+test('#addError adds an error to the changeset using the shortcut', function (assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('email', 'jim@bob.com');
+  dummyChangeset.addError('email', 'Email already taken');
+
+  assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+  assert.equal(get(dummyChangeset, 'error.email.validation'), 'Email already taken', 'should add the error');
+  assert.equal(get(dummyChangeset, 'error.email.value'), 'jim@bob.com', 'addError uses already present value');
+  dummyChangeset.set('email', 'unique@email.com');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+});
+
+test('#pushErrors pushes an error into an array of existing validations', function (assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('email', 'jim@bob.com');
+  dummyChangeset.addError('email', 'Email already taken');
+  dummyChangeset.pushErrors('email', 'Invalid email format');
+
+  assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+  assert.deepEqual(get(dummyChangeset, 'error.email.validation'), ['Email already taken', 'Invalid email format'], 'should push the error');
+  assert.equal(get(dummyChangeset, 'error.email.value'), 'jim@bob.com', 'pushErrors uses already present value');
+  dummyChangeset.set('email', 'unique@email.com');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+});
+
+test('#pushErrors pushes an error if no existing validations are present', function (assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'J');
+  dummyChangeset.pushErrors('name', 'cannot be J');
+
+  assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+  assert.deepEqual(get(dummyChangeset, 'error.name.validation'), ['too short', 'cannot be J'], 'should push the error');
+  assert.equal(get(dummyChangeset, 'error.name.value'), 'J', 'pushErrors uses already present value');
+  dummyChangeset.set('name', 'Good name');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+});
+
+test('#snapshot creates a snapshot of the changeset', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'Pokemon Go');
+  dummyChangeset.set('password', false);
+  let snapshot = dummyChangeset.snapshot();
+  let expectedResult = {
+    changes: { name: 'Pokemon Go' },
+    errors: { password: { validation: ['foo', 'bar'], value: false } }
+  };
+
+  assert.deepEqual(snapshot, expectedResult, 'should return snapshot');
+  dummyChangeset.set('name', "Gotta catch'em all");
+  assert.deepEqual(snapshot, expectedResult, 'should not be mutated');
+});
+
+test('#restore restores a snapshot of the changeset', function(assert) {
+  let dummyChangesetA = new Changeset(dummyModel, dummyValidator);
+  let dummyChangesetB = new Changeset(dummyModel, dummyValidator);
+  dummyChangesetA.set('name', 'Pokemon Go');
+  dummyChangesetA.set('password', false);
+  let snapshot = dummyChangesetA.snapshot();
+
+  assert.ok(get(dummyChangesetB, 'isValid'), 'precondition - should be valid');
+  dummyChangesetB.restore(snapshot);
+  assert.ok(get(dummyChangesetB, 'isInvalid'), 'should be invalid');
+  assert.equal(get(dummyChangesetB, 'change.name'), 'Pokemon Go', 'should restore changes');
+  assert.deepEqual(get(dummyChangesetB, 'error.password'), { validation: ['foo', 'bar'], value: false }, 'should restore errors');
+});
+
+test('#cast allows only specified keys to exist on the changeset', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  let expectedResult = [
+    { 'key': 'name', 'value': 'Pokemon Go' },
+    { 'key': 'password', 'value': true }
+  ];
+  let allowed = ['name', 'password'];
+  dummyChangeset.set('name', 'Pokemon Go');
+  dummyChangeset.set('password', true);
+  dummyChangeset.set('unwantedProp', 123);
+  dummyChangeset.cast(allowed);
+
+  assert.deepEqual(dummyChangeset.get('changes'), expectedResult, 'should drop `unwantedProp');
+  assert.equal(dummyChangeset.get('unwantedProp'), undefined, 'should remove unwanted changes');
+});
+
+test('#cast noops if no keys are passed', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  let expectedResult = [
+    { 'key': 'name', 'value': 'Pokemon Go' },
+    { 'key': 'password', 'value': true },
+    { 'key': 'unwantedProp', 'value': 123 }
+  ];
+  dummyChangeset.set('name', 'Pokemon Go');
+  dummyChangeset.set('password', true);
+  dummyChangeset.set('unwantedProp', 123);
+  dummyChangeset.cast();
+
+  assert.deepEqual(dummyChangeset.get('changes'), expectedResult, 'should drop `unwantedProp');
+});
+
+test("isPristine returns true if changes are equal to content's values", function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  assert.ok(dummyChangeset.get('isPristine'), 'should be pristine');
+});
+
+test("isPristine returns false if changes are not equal to content's values", function(assert) {
+  dummyModel.set('name', 'Bobby');
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'Bobby');
+  dummyChangeset.set('thing', 123);
+
+  assert.notOk(dummyChangeset.get('isPristine'), 'should not be pristine');
+});
+
+test('isPristine works with `null` values', function(assert) {
+  dummyModel.set('name', null);
+  dummyModel.set('age', 15);
+  let dummyChangeset = new Changeset(dummyModel);
+
+  assert.ok(dummyChangeset.get('isPristine'), 'should be pristine');
+
+  dummyChangeset.set('name', 'Kenny');
+  assert.notOk(dummyChangeset.get('isPristine'), 'should not be pristine');
+
+  dummyChangeset.set('name', null);
+  assert.ok(dummyChangeset.get('isPristine'), 'should be pristine');
+});
+
+// Behavior
+test('it works with setProperties', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  let expectedResult = [
+    { key: 'firstName', value: 'foo' },
+    { key: 'lastName', value: 'bar' }
+  ];
+  dummyChangeset.setProperties({ firstName: 'foo', lastName: 'bar' });
+
+  assert.deepEqual(get(dummyChangeset, 'changes'), expectedResult, 'precondition');
+});
+
+test('it accepts async validations', function(assert) {
+  let done = assert.async();
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  let expectedChanges = [{ key: 'async', value: true }];
+  let expectedError = { async: { validation: 'is invalid', value: 'is invalid' } };
+  run(() => dummyChangeset.set('async', true));
+  run(() => assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'should set change'));
+  run(() => dummyChangeset.set('async', 'is invalid'));
+  run(() => {
+    assert.deepEqual(get(dummyChangeset, 'error'), expectedError, 'should set error');
+    done();
+  });
+});
+
+test('it clears errors when setting to original value', function(assert) {
+  set(dummyModel, 'name', 'Jim Bob');
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', '');
+
+  assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+  dummyChangeset.set('name', 'Jim Bob');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+  assert.notOk(get(dummyChangeset, 'isInvalid'), 'should be valid');
+});
+
+test('#execute changes model if valid', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('name', 'foo');
+
+  assert.equal(get(dummyChangeset, 'content'), dummyModel, 'precondition');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+  dummyChangeset.execute();
+  assert.notEqual(get(dummyChangeset, 'content'), dummyModel, 'should apply changes');
+});
+
+test('#execute does not changes model if invalid', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'a');
+
+  assert.equal(get(dummyChangeset, 'content'), dummyModel, 'precondition');
+  assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+  dummyChangeset.execute();
+  assert.equal(get(dummyChangeset, 'content'), dummyModel, 'should apply changes');
+});
+
+test('used twice in subchangeset should set same created model', function (assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  let dummyChangeset2 = new Changeset(dummyModel);
+  dummyChangeset.set('a', dummyChangeset2);
+  dummyChangeset.set('b', dummyChangeset2);
+  dummyChangeset2.set('a', 'a');
+  dummyChangeset.execute();
+  assert.equal(get(dummyChangeset, 'content.a'), get(dummyChangeset, 'content.b'), 'has to be same model');
+  assert.equal(get(dummyChangeset, 'content.a.a'), 'a', 'should be set');
+});
+

--- a/tests/unit/changeset-subchangeset-test.js
+++ b/tests/unit/changeset-subchangeset-test.js
@@ -1,0 +1,220 @@
+import Ember from 'ember';
+import Changeset from 'ember-changeset';
+import wait from 'ember-test-helpers/wait';
+import { module, test } from 'qunit';
+
+const {
+  Object: EmberObject,
+  RSVP: { resolve },
+  get,
+  isPresent,
+  set,
+  typeOf
+} = Ember;
+
+let dummyModel;
+let dummyModel2;
+let dummyModel3;
+let dummyModel4;
+let dummyValidations = {
+  name(value) {
+    return isPresent(value) && value.length > 3 || 'too short';
+  },
+  password(value) {
+    return value || ['foo', 'bar'];
+  },
+  passwordConfirmation(newValue, _oldValue, { password: changedPassword }, { password }) {
+    return isPresent(newValue) && (changedPassword === newValue || password === newValue) || "password doesn't match";
+  },
+  async(value) {
+    return resolve(value);
+  },
+  options(value) {
+    return isPresent(value);
+  }
+};
+
+function dummyValidator({ key, newValue, oldValue, changes, content }) {
+  let validatorFn = dummyValidations[key];
+
+  if (typeOf(validatorFn) === 'function') {
+    return validatorFn(newValue, oldValue, changes, content);
+  }
+}
+
+module('Unit | Utility | changeset subchangesets', {
+  beforeEach() {
+    let Dummy = EmberObject.extend({
+      save() {
+        return resolve(this);
+      }
+    });
+    dummyModel = Dummy.create();
+    dummyModel2 = Dummy.create();
+    dummyModel3 = Dummy.create();
+    dummyModel4 = Dummy.create();
+  }
+});
+
+// Methods
+test('get subchangesets', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  let dummyChangeset2 = new Changeset(dummyModel2);
+  let dummyChangeset3 = new Changeset(dummyModel3);
+  let dummyChangeset4 = new Changeset(dummyModel4);
+  set(dummyChangeset, 'a', 'a');
+  set(dummyChangeset, 'b', dummyChangeset2);
+  set(dummyChangeset, 'c', 'c');
+  let arr = ['a', dummyChangeset3, 'c', dummyChangeset4, 'd'];
+  set(dummyChangeset, 'd', arr);
+  set(dummyChangeset, 'e', 'e');
+  let result = get(dummyChangeset, 'subChangesets');
+
+  assert.deepEqual(result, [dummyChangeset2, dummyChangeset3, dummyChangeset4], 'should return all subchangesets');
+});
+
+test('isAllValid invalid if changeset invalid', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('password', false);
+  let isAllValid = get(dummyChangeset, 'isAllValid');
+  let isAllInvalid = get(dummyChangeset, 'isAllInvalid');
+
+  assert.notOk(isAllValid, 'should not be valid');
+  assert.ok(isAllInvalid, 'should be invalid');
+});
+
+test('isAllValid invalid if a subchangeset invalid', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  let dummyChangeset2 = new Changeset(dummyModel2, dummyValidator);
+  let dummyChangeset3 = new Changeset(dummyModel3, dummyValidator);
+  dummyChangeset.set('password', true);
+  dummyChangeset2.set('password', false);
+  dummyChangeset3.set('password', true);
+  set(dummyChangeset, 'a', dummyChangeset2);
+  set(dummyChangeset, 'b', dummyChangeset3);
+
+  let isAllValid = get(dummyChangeset, 'isAllValid');
+  let isAllInvalid = get(dummyChangeset, 'isAllInvalid');
+
+  assert.notOk(isAllValid, 'should not be valid');
+  assert.ok(isAllInvalid, 'should be invalid');
+});
+
+test('isAllValid valid if changeset valid and all sub changesets valid', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  let dummyChangeset2 = new Changeset(dummyModel2, dummyValidator);
+  dummyChangeset.set('password', true);
+  dummyChangeset2.set('password', true);
+  set(dummyChangeset, 'a', dummyChangeset2);
+
+  let isAllValid = get(dummyChangeset, 'isAllValid');
+  let isAllInvalid = get(dummyChangeset, 'isAllInvalid');
+
+  assert.ok(isAllValid, 'should be valid');
+  assert.notOk(isAllInvalid, 'should not be invalid');
+});
+
+test('isAllPristine is false if changeset is not pristine', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  dummyChangeset.set('password', false);
+  let isAllPristine = get(dummyChangeset, 'isAllPristine');
+  let isSomeDirty = get(dummyChangeset, 'isSomeDirty');
+
+  assert.notOk(isAllPristine, 'should not be pristine');
+  assert.ok(isSomeDirty, 'should be dirty');
+});
+
+test('isAllPristine is true if changeset is pristine', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  let isAllPristine = get(dummyChangeset, 'isAllPristine');
+  let isSomeDirty = get(dummyChangeset, 'isSomeDirty');
+
+  assert.ok(isAllPristine, 'should be pristine');
+  assert.notOk(isSomeDirty, 'should not be dirty');
+});
+
+test('execute should execute all subchangesets and replace the changesets with the content', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+  let dummyChangeset2 = new Changeset(dummyModel2);
+  let dummyChangeset3 = new Changeset(dummyModel3);
+  let dummyChangeset4 = new Changeset(dummyModel4);
+  set(dummyChangeset, 'a', 'a');
+  set(dummyChangeset2, 'a', 'a');
+  set(dummyChangeset, 'b', dummyChangeset2);
+  set(dummyChangeset, 'c', 'c');
+  set(dummyChangeset3, 'a', 'a');
+  set(dummyChangeset4, 'a', 'a');
+  let arr = ['a', dummyChangeset3, 'c', dummyChangeset4, 'd'];
+  set(dummyChangeset, 'd', arr);
+  set(dummyChangeset, 'e', 'e');
+
+  dummyChangeset.execute();
+
+
+  assert.equal(dummyModel.get('a'), 'a', 'should update changes (a)');
+  assert.equal(dummyModel.get('b'), dummyModel2, 'should update changes (b)');
+  assert.equal(dummyModel2.get('a'), 'a', 'should update changes (b.a)');
+  assert.equal(dummyModel.get('c'), 'c', 'should update changes (c)');
+  assert.deepEqual(dummyModel.get('d'), ['a', dummyModel3, 'c', dummyModel4, 'd'], 'should update changes (d)');
+  assert.equal(dummyModel3.get('a'), 'a', 'should update changes (d.1.a)');
+  assert.equal(dummyModel4.get('a'), 'a', 'should update changes (d.2.a)');
+  assert.equal(dummyModel.get('e'), 'e', 'should update changes (d)');
+});
+
+test('save should save all subchangesets', function(assert) {
+  assert.expect(14);
+  let result;
+  let options;
+  set(dummyModel, 'save', (dummyOptions) => {
+    result = 'ok';
+    options = dummyOptions;
+    return resolve('saveResult');
+  });
+  let result2;
+  let options2;
+  set(dummyModel2, 'save', (dummyOptions) => {
+    result2 = 'ok';
+    options2 = dummyOptions;
+    return resolve('saveResult');
+  });
+  let result3;
+  let options3;
+  set(dummyModel3, 'save', (dummyOptions) => {
+    result3 = 'ok';
+    options3 = dummyOptions;
+    return resolve('saveResult');
+  });
+
+  let dummyChangeset = new Changeset(dummyModel);
+  let dummyChangeset2 = new Changeset(dummyModel2);
+  let dummyChangeset3 = new Changeset(dummyModel3);
+  set(dummyChangeset, 'a', dummyChangeset2);
+  set(dummyChangeset, 'b', [dummyChangeset3]);
+
+  assert.equal(result, undefined, 'precondition');
+  assert.equal(result2, undefined, 'precondition');
+  assert.equal(result3, undefined, 'precondition');
+  let promise = dummyChangeset.save('test options');
+  assert.equal(result, 'ok', 'should save');
+  assert.equal(result2, 'ok', 'should save');
+  assert.equal(result3, 'ok', 'should save');
+  assert.equal(options, 'test options', 'should proxy options when saving');
+  assert.equal(options2, 'test options', 'should proxy options when saving');
+  assert.equal(options3, 'test options', 'should proxy options when saving');
+  assert.ok(!!promise && typeof promise.then === 'function', 'save returns a promise');
+
+  promise.then((saveResult) => {
+    assert.equal(saveResult.length, 3, 'should be array with three objects');
+    assert.equal(saveResult[0].value, 'saveResult', 'save proxies to save promise of content');
+    assert.equal(saveResult[1].value, 'saveResult', 'save proxies to save promise of content');
+    assert.equal(saveResult[2].value, 'saveResult', 'save proxies to save promise of content');
+  });
+  return wait();
+
+
+
+});
+
+
+
+


### PR DESCRIPTION
I know this works a little bit against #140 but what do you guys think?

I added two things:
A) You can create a changeset without a model. The model then gets created when you execute the changset. A user can for example fill out a form without the need to create a ember data model beforehand and therefore you don't have to clean it up if he uses the back button or anything else.

`dummyModel = new NewEDModel("myModelName", Store.create);`
` let dummyChangeset = new Changeset(dummyModel);`
 `dummyChangeset.execute();`

On execute the Store.create function gets called with the "myModelName" string. Then the content value gets replaced with the new created model and then the changes get applied.
I am not happy with the class name yet but maybe somebody else has an idea.

B) Instead of setting a object you can set a subchangeset instead. This works for values and objects in arrays. When executing the changeset, it looks for subchangesets and if they are valid. If all are valid all the changesets get executed.

`let dummyChangeset = new Changeset(dummyModel);`
 ` let dummyChangeset2 = new Changeset(dummyModel2);`
  `let dummyChangeset3 = new Changeset(dummyModel3);`
  `let dummyChangeset4 = new Changeset(dummyModel4);`
  `dummyChangeset.set('a', 'a');`
  `dummyChangeset.set('b', dummyChangeset2);`
  `dummyChangeset.set('c', 'c');`
  `let arr = ['a', dummyChangeset3, 'c', dummyChangeset4, 'd'];`
  `dummyChangeset.set('d', arr);`
  `dummyChangeset.set('e', 'e');`
  `dummyChangeset.execute()`

Not as automatic as nested keys but it works well with ember data and relations as well as with validation. What do you guys think?