### PR TITLE
Added test case for deeply nested error clearing

### DIFF
--- a/tests/integration/components/changeset-test.js
+++ b/tests/integration/components/changeset-test.js
@@ -207,6 +207,40 @@ test('nested key error clears after entering valid input', async function(assert
   }
 });
 
+test('deeply nested key error clears after entering valid input', async function(assert) {
+  let data = { person: { name: { parts: { first: 'Jim' } } } };
+  let validator = ({ newValue }) => isPresent(newValue) || 'need a first name';
+  let c = new Changeset(data, validator);
+  this.set('c', c);
+
+  this.render(hbs`
+    <h1>{{c.person.name.parts.first}}</h1>
+    <input
+      id="first-name"
+      type="text"
+      value={{c.person.name.parts.first}}
+      onchange={{action (mut c.person.name.parts.first) value="target.value"}}>
+    <small id="first-name-error">{{c.error.person.name.parts.first.validation}}</small>
+  `);
+
+  assert.equal(find('h1').textContent.trim(), 'Jim', 'precondition');
+  await fillIn('#first-name', '');
+
+  {
+    let actual = find('#first-name-error').textContent.trim();
+    let expectedResult = 'need a first name';
+    assert.equal(actual, expectedResult, 'shows error message');
+  }
+
+  await fillIn('#first-name', 'foo');
+
+  {
+    let actual = find('#first-name-error').textContent.trim();
+    let expectedResult = '';
+    assert.equal(actual, expectedResult, 'hides error message');
+  }
+});
+
 test('a rollback propagates binding to deeply nested changesets', async function(assert) {
   let data = { person: { firstName: 'Jim', lastName: 'Bob' } };
   let changeset = new Changeset(data);


### PR DESCRIPTION
Tests if a deeply nested error is cleared after entering a valid input (Test passed on 1.1.3)