### PR TITLE
Fix rollback() property notifiers

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -251,7 +251,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
       }
 
       // Get keys before resetting
-      const keys = this._rollbackKeys()
+      let keys = this._rollbackKeys();
 
       set(this, RELAY_CACHE, {});
       set(this, CHANGES, {});
@@ -678,7 +678,7 @@ export function changeset(obj, validateFn = defaultValidatorFn, validationMap = 
     },
 
     /**
-     * Gets the changes and error keys
+     * Gets the changes and error keys.
      *
      * @private
      * @return {Array}

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -320,6 +320,18 @@ test('#rollback resets valid state', function(assert) {
   assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
 });
 
+test('observing #rollback values', function(assert) {
+  let res;
+  const changeset = new Changeset(dummyModel, dummyValidator);
+  changeset.addObserver('name', function() { res = this.get('name') });
+  changeset.get('name');
+  assert.equal(undefined, changeset.get('name'), 'initial value');
+  changeset.set('name', 'Jack');
+  assert.equal('Jack', res, 'observer fired when setting value');
+  changeset.rollback();
+  assert.equal(undefined, res, 'observer fired with the value name was rollback to');
+});
+
 test('#error returns the error object', function(assert) {
   let dummyChangeset = new Changeset(dummyModel, dummyValidator);
   let expectedResult = { name: { validation: 'too short', value: 'a' } };

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -324,7 +324,6 @@ test('observing #rollback values', function(assert) {
   let res;
   let changeset = new Changeset(dummyModel, dummyValidator);
   changeset.addObserver('name', function() { res = this.get('name') });
-  changeset.get('name');
   assert.equal(undefined, changeset.get('name'), 'initial value');
   changeset.set('name', 'Jack');
   assert.equal('Jack', res, 'observer fired when setting value');

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -322,7 +322,7 @@ test('#rollback resets valid state', function(assert) {
 
 test('observing #rollback values', function(assert) {
   let res;
-  const changeset = new Changeset(dummyModel, dummyValidator);
+  let changeset = new Changeset(dummyModel, dummyValidator);
   changeset.addObserver('name', function() { res = this.get('name') });
   changeset.get('name');
   assert.equal(undefined, changeset.get('name'), 'initial value');


### PR DESCRIPTION
Fixes #217

Added keys argument to _notifyVirtualProperties(), so you can pass in
an array of keys instead of always using the changes and error keys.

rollback() has been changed to get the keys first, and then notify the
properties after resetting the changes and errors.

Added _rollbackKeys() private function, so rollback() and
_notifyVirtualProperties() can use the keys in different ways.