### PR TITLE
Fix leaf keys with promises

### DIFF
--- a/addon/utils/leaf-keys.js
+++ b/addon/utils/leaf-keys.js
@@ -1,4 +1,5 @@
 import isObject from 'ember-changeset/utils/is-object';
+import isPromise from 'ember-changeset/utils/is-promise';
 import { isArray } from '@ember/array';
 
 /**
@@ -11,13 +12,18 @@ const _leafKeys = function(object = {}, scope = '') {
     const value = object[key];
     let newKeys = [scope + key];
 
-    if (isObject(value) && !isArray(value) && Object.keys(value).length) {
+    if (
+      isObject(value) &&
+      !isPromise(value) &&
+      !isArray(value) &&
+      Object.keys(value).length
+    ) {
       newKeys = _leafKeys(value, scope + key + '.');
     }
 
     return keys.concat(newKeys);
   }, []);
-}
+};
 
 /**
  * Given an object, return an array of the leaf-most keys

--- a/tests/unit/utils/leaf-keys-test.js
+++ b/tests/unit/utils/leaf-keys-test.js
@@ -1,6 +1,6 @@
 import leafKeys from 'ember-changeset/utils/leaf-keys';
 import { module, test } from 'qunit';
-
+import RSVP from 'rsvp';
 import EmberObject from '@ember/object';
 
 module('Unit | Utility | leaf-keys');
@@ -132,6 +132,16 @@ const TEST_DATA = [{
     'item.innerItem.nest.thing',
     'item.innerItem.nest.other',
   ],
+}, {
+  desc: 'it ignores promises',
+  input: {
+    foo: {
+      bar: new RSVP.Promise(() => {})
+    }
+  },
+  expected: [
+    'foo.bar',
+  ]
 }];
 
 function nullCreatedObjects() {


### PR DESCRIPTION
When leafKeys encountered a promise, there would be lots of extra keys from the promise object like x._id and about 5 others. This fixes that. Needed for #233