### PR TITLE
WIP: Fix stack overflow bug

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -411,14 +411,16 @@ export function changeset(
 
       if (isNone(key)) {
         let maybePromise = keys(validationMap).map(validationKey => {
-          return c._validateAndSet(validationKey, c._valueFor(validationKey));
+          const isPlain = true;
+          return c._validateAndSet(validationKey, c._valueFor(validationKey, isPlain));
         });
 
         return all(maybePromise);
       }
 
       let k /*: string */ = (key /*: any */);
-      return resolve(c._validateAndSet(k, c._valueFor(k)));
+      const isPlain = true;
+      return resolve(c._validateAndSet(k, c._valueFor(k, isPlain)));
     },
 
     /**

--- a/addon/index.js
+++ b/addon/index.js
@@ -629,6 +629,8 @@ export function changeset(
       validation               /*: ValidationResult */,
       { key, value, oldValue } /*: NewProperty<T>   */
     ) /*: T | ErrLike<T> */ {
+      assert('Value must not be a Relay. If you see this error, please open an issue on https://github.com/poteto/ember-changeset/issues.', !isRelay(value));
+
       let changes /*: Changes */ = get(this, CHANGES);
       let isValid /*: boolean */ = validation === true
         || isArray(validation)

--- a/addon/utils/is-relay.js
+++ b/addon/utils/is-relay.js
@@ -5,7 +5,7 @@ import { isPresent } from '@ember/utils';
 
 export const RELAY = '__RELAY__';
 
-export default function isRelay(relay /*: Object */) /*: boolean */ {
+export default function isRelay(relay /*: mixed */) /*: boolean */ {
   if (!isPresent(relay)) return false;
   return get(relay, '__relay__') === RELAY;
 }


### PR DESCRIPTION
Closes #272.

The root of the problem is that we were setting Relays on a Changeset's internal `changes` and `errors` objects. Changesets and Relays reference each other, so it makes sense that there would be a stack overflow.

This indicates that Relays are somewhat brittle. We may be able to replace Relays with [`validated-proxy`](https://github.com/poteto/validated-proxy) at some point if there is enough interest.