### PR TITLE
Expose changeset content

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Be sure to call `validate()` on the `changeset` before saving or committing chan
   + [`change`](#change)
   + [`errors`](#errors)
   + [`changes`](#changes)
+  + [`data`](#data)
   + [`isValid`](#isvalid)
   + [`isInvalid`](#isinvalid)
   + [`isPristine`](#ispristine)
@@ -294,6 +295,19 @@ You can use this property to render a list of changes:
     <li>{{change.key}}: {{change.value}}</li>
   {{/each}}
 </ul>
+```
+
+**[⬆️ back to top](#api)**
+
+#### `data`
+
+Returns the Object that was wrapped in the changeset.
+
+```js
+let user = { name: 'Bobby', age: 21, address: { zipCode: '10001' } };
+let changeset = new Changeset(user);
+
+changeset.get('data'); // user
 ```
 
 **[⬆️ back to top](#api)**

--- a/addon/index.js
+++ b/addon/index.js
@@ -37,7 +37,10 @@ import {
   isPresent,
   typeOf,
 } from '@ember/utils';
-import { not } from '@ember/object/computed';
+import {
+  not,
+  readOnly,
+} from '@ember/object/computed';
 import {
   get,
   set,
@@ -115,6 +118,7 @@ export type ChangesetDef = {|
   errors:  Array<{ key: string }>,
   change:  Inflated<mixed>,
   error:   Inflated<ErrLike<mixed>>,
+  data:    Object,
 
   isValid:    boolean,
   isPristine: boolean,
@@ -177,6 +181,7 @@ export function changeset(
     errors:  objectToArray(ERRORS, (e /*: Err */) => ({ value: e.value, validation: e.validation }), true),
     change:  inflate(CHANGES, c => c.value),
     error:   inflate(ERRORS, e => ({ value: e.value, validation: e.validation })),
+    data:    readOnly(CONTENT),
 
     isValid:    isEmptyObject(ERRORS),
     isPristine: isEmptyObject(CHANGES),

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -99,6 +99,26 @@ test('#change returns the changes object', function(assert) {
  */
 
 /**
+ * #data
+ */
+
+test("data reads the changeset CONTENT", function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+
+  assert.equal(get(dummyChangeset, 'data'), dummyModel, 'should return data');
+});
+
+test("data is readonly", function(assert) {
+  let dummyChangeset = new Changeset(dummyModel);
+
+  assert.throws(
+    () => set(dummyChangeset, 'data', { foo: 'bar' }),
+    ({message}) => message === "Cannot set read-only property 'data' on object: changeset:[object Object]",
+    'should throw error'
+  );
+});
+
+/**
  * #isValid
  */
 


### PR DESCRIPTION
## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->

This PR adds a new readonly getter that returns the object that was wrapped in the changeset.
The change can potentially close https://github.com/poteto/ember-changeset/issues/139 as it exposes a way to access `_content`.

I'm unsure if `content` is a good name as it potentially conflicts with the proxied objects `content` attribute.