### PR TITLE
add an afterRollback event

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Be sure to call `validate()` on the `changeset` before saving or committing chan
 * Events
   + [`beforeValidation`](#beforevalidation)
   + [`afterValidation`](#aftervalidation)
+  + [`afterRollback`](#afterrollback)
 
 #### `error`
 
@@ -739,6 +740,22 @@ changeset.validate().then(() => {
   // console output: lastName has completed validating
   // console output: address.city has completed validating
 });
+```
+
+**[⬆️ back to top](#api)**
+
+#### `afterRollback`
+
+This event is triggered after a rollback of the changeset.
+This can be used for [some advanced use cases](https://github.com/offirgolan/ember-changeset-cp-validations/issues/25#issuecomment-375855834)
+where it is necessary to separately track all changes that are made to the changeset.
+
+```js
+changeset.on('afterRollback', () => {
+  console.log("changeset has rolled back");
+});
+changeset.rollback();
+// console output: changeset has rolled back
 ```
 
 **[⬆️ back to top](#api)**

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1244,6 +1244,30 @@ test('afterValidation event is triggered with the key', function(assert) {
 });
 
 /**
+ * afterRollback
+ */
+
+test('afterRollback event is fired after rollback', function(assert) {
+  let dummyChangeset;
+  let _validator = () => resolve(true);
+  let _validations = {
+    reservations() {
+      return _validator();
+    }
+  };
+  let hasFired = false;
+
+  set(dummyModel, 'reservations', 'ABC12345');
+  dummyChangeset = new Changeset(dummyModel, _validator, _validations);
+  dummyChangeset.on('afterRollback', () => { hasFired = true; });
+
+  run(() => {
+    dummyChangeset.rollback();
+    assert.ok(hasFired, 'afterRollback should be triggered');
+  });
+});
+
+/**
  * Behavior.
  */
 


### PR DESCRIPTION
## Add an `afterRollback` event hook

This adds a new event hook `afterRollback` that gets called at the end of a changeset `rollback()`. I wouldn't have a PR for this if I could cleanly extend the `Changeset` class myself, but, I can't: https://github.com/poteto/ember-changeset/issues/178#issuecomment-375852516

This is required for me to have a reasonably clean solution to https://github.com/offirgolan/ember-changeset-cp-validations/issues/25 . I'll post more info there to help explain why I need this.

Cheers :v: