### PR TITLE
Update ember-cli-babel to ^6.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/DockYard/ember-changeset/issues",
   "homepage": "https://github.com/DockYard/ember-changeset",
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^6.12.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
ember-cli-babel 5.x.x is depreciated.
ember-changeset 1.4.x and 1.5.x still have bugs.

Propose releasing ember-changeset 1.3.1 which is the same as 1.3.0 but with the ember-cli-babel dependency updated to be ^6.12.0.

Thoughts?
