### PR TITLE
Ensure error changes are added to changes block

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,7 +902,9 @@ export default Component.extend({
     }
   }
 });
+```
 
+```hbs
 <input
   type={{type}}
   value={{get model valuePath}}

--- a/addon/index.js
+++ b/addon/index.js
@@ -417,8 +417,11 @@ export function changeset(
     rollbackInvalid(key /*: string | void */) /*: ChangesetDef */ {
       if (key) {
         this._notifyVirtualProperties([key]);
+        let errorKeys = keys(get(this, ERRORS));
         this._deleteKey(ERRORS, key);
-        this._deleteKey(CHANGES, key);
+        if (errorKeys.indexOf(key) > -1) {
+          this._deleteKey(CHANGES, key);
+        }
       } else {
         this._notifyVirtualProperties();
         let errorKeys = keys(get(this, ERRORS));

--- a/addon/index.js
+++ b/addon/index.js
@@ -633,7 +633,6 @@ export function changeset(
       // TODO: Address case when Promise is rejected.
       if (isPromise(validation)) {
         c._setIsValidating(key, true);
-        c.trigger(BEFORE_VALIDATION_EVENT, key);
 
         return v.then(resolvedValidation => {
           c._setIsValidating(key, false);

--- a/addon/index.js
+++ b/addon/index.js
@@ -492,7 +492,6 @@ export function changeset(
 
       // Remove `key` from changes map.
       let c = (this /*: ChangesetDef */);
-      c._deleteKey(CHANGES, key);
 
       // Add `key` to errors map.
       let errors /*: Errors */ = get(this, ERRORS);
@@ -689,12 +688,6 @@ export function changeset(
       // Shorthand for `this`.
       let c /*: ChangesetDef */ = this;
 
-      // Error case.
-      if (!isValid) {
-        let v /*: ValidationErr */ = (validation /*: any */);
-        return c.addError(key, { value, validation: v });
-      }
-
       // Happy path: remove `key` from error map.
       c._deleteKey(ERRORS, key);
 
@@ -714,6 +707,12 @@ export function changeset(
       // Happy path: notify that `key` was added.
       c.notifyPropertyChange(CHANGES);
       c.notifyPropertyChange(key);
+
+      // Error case.
+      if (!isValid) {
+        let v /*: ValidationErr */ = (validation /*: any */);
+        return c.addError(key, { value, validation: v });
+      }
 
       // Return new value.
       return value;

--- a/addon/index.js
+++ b/addon/index.js
@@ -411,16 +411,23 @@ export function changeset(
      *
      * @public
      * @chainable
-     * @param {String} key optional key to rollback invalid
+     * @param {String} key optional key to rollback invalid values
      * @return {Changeset}
      */
     rollbackInvalid(key /*: string | void */) /*: ChangesetDef */ {
       if (key) {
         this._notifyVirtualProperties([key]);
         this._deleteKey(ERRORS, key);
+        this._deleteKey(CHANGES, key);
       } else {
         this._notifyVirtualProperties();
+        let errorKeys = keys(get(this, ERRORS));
         set(this, ERRORS, {});
+
+        // if on CHANGES hash, rollback those as well
+        errorKeys.forEach((errKey) => {
+          this._deleteKey(CHANGES, errKey);
+        })
       }
 
       return this;
@@ -830,7 +837,9 @@ export function changeset(
       key     /*: string */ = ''
     ) /*: void */ {
       let obj /*: InternalMap */ = get(this, objName);
-      if (obj.hasOwnProperty(key)) delete obj[key];
+      if (obj.hasOwnProperty(key)) {
+        delete obj[key];
+      }
       let c /*: ChangesetDef */ = this;
       c.notifyPropertyChange(`${objName}.${key}`);
       c.notifyPropertyChange(objName);

--- a/addon/index.js
+++ b/addon/index.js
@@ -415,16 +415,16 @@ export function changeset(
      * @return {Changeset}
      */
     rollbackInvalid(key /*: string | void */) /*: ChangesetDef */ {
+      let errorKeys = keys(get(this, ERRORS));
+
       if (key) {
         this._notifyVirtualProperties([key]);
-        let errorKeys = keys(get(this, ERRORS));
         this._deleteKey(ERRORS, key);
         if (errorKeys.indexOf(key) > -1) {
           this._deleteKey(CHANGES, key);
         }
       } else {
         this._notifyVirtualProperties();
-        let errorKeys = keys(get(this, ERRORS));
         set(this, ERRORS, {});
 
         // if on CHANGES hash, rollback those as well

--- a/addon/index.js
+++ b/addon/index.js
@@ -625,12 +625,14 @@ export function changeset(
       let validation /*: ValidationResult | Promise<ValidationResult> */ =
         c._validate(key, value, oldValue);
 
+      let v /*: ValidationResult */ = (validation /*: any */);
+      let result = c._setProperty(v, { key, value, oldValue });
+
       // TODO: Address case when Promise is rejected.
       if (isPromise(validation)) {
         c._setIsValidating(key, true);
         c.trigger(BEFORE_VALIDATION_EVENT, key);
 
-        let v /*: Promise<ValidationResult> */ = (validation /*: any */);
         return v.then(resolvedValidation => {
           c._setIsValidating(key, false);
           c.trigger(AFTER_VALIDATION_EVENT, key);
@@ -640,8 +642,8 @@ export function changeset(
 
       c.trigger(BEFORE_VALIDATION_EVENT, key);
       c.trigger(AFTER_VALIDATION_EVENT, key);
-      let v /*: ValidationResult */ = (validation /*: any */);
-      return c._setProperty(v, { key, value, oldValue });
+
+      return result;
     },
 
     /**

--- a/addon/index.js
+++ b/addon/index.js
@@ -634,6 +634,7 @@ export function changeset(
       if (isPromise(validation)) {
         c._setIsValidating(key, true);
 
+        let v /*: Promise<ValidationResult> */ = (validation /*: any */);
         return v.then(resolvedValidation => {
           c._setIsValidating(key, false);
           c.trigger(AFTER_VALIDATION_EVENT, key);

--- a/addon/index.js
+++ b/addon/index.js
@@ -626,6 +626,8 @@ export function changeset(
         c._validate(key, value, oldValue);
 
       let v /*: ValidationResult */ = (validation /*: any */);
+
+      c.trigger(BEFORE_VALIDATION_EVENT, key);
       let result = c._setProperty(v, { key, value, oldValue });
 
       // TODO: Address case when Promise is rejected.
@@ -640,7 +642,6 @@ export function changeset(
         });
       }
 
-      c.trigger(BEFORE_VALIDATION_EVENT, key);
       c.trigger(AFTER_VALIDATION_EVENT, key);
 
       return result;

--- a/addon/utils/computed/object-to-array.js
+++ b/addon/utils/computed/object-to-array.js
@@ -2,10 +2,10 @@
 
 import { computed, get } from '@ember/object';
 import { typeOf } from '@ember/utils';
-import { assign } from '@ember/polyfills';
+import { assign as EmberAssign } from '@ember/polyfills';
 import { merge } from '@ember/polyfills'
 
-const assign = assign || merge;
+const assign = EmberAssign || merge;
 
 /*::
 import type Change from 'ember-changeset/-private/change';

--- a/addon/utils/computed/object-to-array.js
+++ b/addon/utils/computed/object-to-array.js
@@ -3,6 +3,9 @@
 import { computed, get } from '@ember/object';
 import { typeOf } from '@ember/utils';
 import { assign } from '@ember/polyfills';
+import { merge } from '@ember/polyfills'
+
+const assign = assign || merge;
 
 /*::
 import type Change from 'ember-changeset/-private/change';

--- a/addon/utils/computed/object-to-array.js
+++ b/addon/utils/computed/object-to-array.js
@@ -2,7 +2,7 @@
 
 import { computed, get } from '@ember/object';
 import { typeOf } from '@ember/utils';
-import pureAssign from 'ember-changeset/utils/assign';
+import { assign } from '@ember/polyfills';
 
 /*::
 import type Change from 'ember-changeset/-private/change';
@@ -34,7 +34,7 @@ export default function objectToArray /*:: <T> */ (
       let value = transform(obj[key]);
 
       if (flattenObjects && typeOf(value) === 'object') {
-        return pureAssign({ key }, value);
+        return assign({ key }, value);
       }
 
       return { key, value };

--- a/addon/utils/computed/object-to-array.js
+++ b/addon/utils/computed/object-to-array.js
@@ -1,8 +1,8 @@
 // @flow
 
-import Ember from 'ember';
 import { computed, get } from '@ember/object';
 import { typeOf } from '@ember/utils';
+import pureAssign from 'ember-changeset/utils/assign';
 
 /*::
 import type Change from 'ember-changeset/-private/change';
@@ -10,8 +10,6 @@ import type Err from 'ember-changeset/-private/err';
 */
 
 const { keys } = Object;
-// eslint-disable-next-line ember/new-module-imports
-const assign = Ember.assign || Ember.merge;
 
 /**
  * Compute the array form of an object.
@@ -36,7 +34,7 @@ export default function objectToArray /*:: <T> */ (
       let value = transform(obj[key]);
 
       if (flattenObjects && typeOf(value) === 'object') {
-        return assign({ key }, value);
+        return pureAssign({ key }, value);
       }
 
       return { key, value };

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -681,6 +681,7 @@ test('#save proxies to content', function(assert) {
   assert.equal(result, undefined, 'precondition');
   let promise = dummyChangeset.save('test options');
   assert.equal(result, 'ok', 'should save');
+  assert.deepEqual(get(dummyChangeset, 'change'), { name: 'foo' }, 'should save');
   assert.equal(options, 'test options', 'should proxy options when saving');
   assert.ok(!!promise && typeof promise.then === 'function', 'save returns a promise');
   promise.then((saveResult) => {
@@ -1273,7 +1274,7 @@ test('#cast noops if no keys are passed', function(assert) {
  * #isValidating
  */
 
-test('isValidating returns true when validations have not resolved', function(assert) {
+test('scott isValidating returns true when validations have not resolved', function(assert) {
   let dummyChangeset;
   let _validator = () => new Promise(() => {});
   let _validations = {
@@ -1284,8 +1285,11 @@ test('isValidating returns true when validations have not resolved', function(as
 
   set(dummyModel, 'reservations', 'ABC12345');
   dummyChangeset = new Changeset(dummyModel, _validator, _validations);
+  set(dummyChangeset, 'reservations', 'DCE12345');
 
   dummyChangeset.validate();
+  assert.deepEqual(get(dummyChangeset, 'change'), { reservations: 'DCE12345' });
+
   assert.ok(dummyChangeset.isValidating(),
     'isValidating should be true when no key is passed in and something is validating');
   assert.ok(dummyChangeset.isValidating('reservations'),

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -925,6 +925,21 @@ test('#rollbackInvalid resets valid state', function(assert) {
   assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
 });
 
+test('#rollbackInvalid will not remove changes that are valid', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  dummyChangeset.set('name', 'abcd');
+
+  let expectedChanges = [
+    { key: 'name', value: 'abcd' },
+  ];
+  assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'has correct changes');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+  dummyChangeset.rollbackInvalid('name');
+  assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'should not remove valid changes');
+  assert.ok(get(dummyChangeset, 'isValid'), 'should still be valid');
+});
+
+
 test('#rollbackInvalid works for keys not on changeset', function(assert) {
   let dummyChangeset = new Changeset(dummyModel, dummyValidator);
   let expectedChanges = [

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1274,7 +1274,7 @@ test('#cast noops if no keys are passed', function(assert) {
  * #isValidating
  */
 
-test('scott isValidating returns true when validations have not resolved', function(assert) {
+test('isValidating returns true when validations have not resolved', function(assert) {
   let dummyChangeset;
   let _validator = () => new Promise(() => {});
   let _validations = {

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -865,7 +865,8 @@ test('#rollbackInvalid clears errors and keeps valid values', function(assert) {
   let dummyChangeset = new Changeset(dummyModel, dummyValidator);
   let expectedChanges = [
     { key: 'firstName', value: 'foo' },
-    { key: 'lastName', value: 'bar' }
+    { key: 'lastName', value: 'bar' },
+    { key: 'name', value: '' }
   ];
   let expectedErrors = [{ key: 'name', validation: 'too short', value: '' }];
   dummyChangeset.set('firstName', 'foo');
@@ -883,7 +884,9 @@ test('#rollbackInvalid a specific key clears key error and keeps valid values', 
   let dummyChangeset = new Changeset(dummyModel, dummyValidator);
   let expectedChanges = [
     { key: 'firstName', value: 'foo' },
-    { key: 'lastName', value: 'bar' }
+    { key: 'lastName', value: 'bar' },
+    { key: 'password', value: false },
+    { key: 'name', value: '' }
   ];
   let expectedErrors = [
     { key: 'password', validation: ['foo', 'bar'], value: false },
@@ -931,7 +934,8 @@ test('#rollbackProperty clears errors for specified property', function(assert) 
   let dummyChangeset = new Changeset(dummyModel, dummyValidator);
   let expectedChanges = [
     { key: 'firstName', value: 'foo' },
-    { key: 'lastName', value: 'bar' }
+    { key: 'lastName', value: 'bar' },
+    { key: 'name', value: '' }
   ];
   let expectedErrors = [{ key: 'name', validation: 'too short', value: '' }];
   dummyChangeset.set('firstName', 'foo');
@@ -941,6 +945,10 @@ test('#rollbackProperty clears errors for specified property', function(assert) 
   assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'precondition');
   assert.deepEqual(get(dummyChangeset, 'errors'), expectedErrors, 'precondition');
   dummyChangeset.rollbackProperty('name');
+  expectedChanges = [
+    { key: 'firstName', value: 'foo' },
+    { key: 'lastName', value: 'bar' }
+  ];
   assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'should not rollback');
   assert.deepEqual(get(dummyChangeset, 'errors'), [], 'should rollback');
 });
@@ -1161,7 +1169,7 @@ test('#addError adds an error to the changeset using the shortcut', function (as
   assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
   assert.equal(get(dummyChangeset, 'error.email.validation'), 'Email already taken', 'should add the error');
   assert.equal(get(dummyChangeset, 'error.email.value'), 'jim@bob.com', 'addError uses already present value');
-  assert.deepEqual(get(dummyChangeset, 'changes'), [], 'pushErrors clears the changes on the changeset');
+  assert.deepEqual(get(dummyChangeset, 'changes'), [{ key: 'email', value: 'jim@bob.com'}], 'errors set as changes on changeset');
   dummyChangeset.set('email', 'unique@email.com');
   assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
   assert.deepEqual(get(dummyChangeset, 'changes')[0], { key: 'email', value: 'unique@email.com' }, 'has correct changes');

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -876,6 +876,10 @@ test('#rollbackInvalid clears errors and keeps valid values', function(assert) {
   assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'precondition');
   assert.deepEqual(get(dummyChangeset, 'errors'), expectedErrors, 'precondition');
   dummyChangeset.rollbackInvalid();
+  expectedChanges = [
+    { key: 'firstName', value: 'foo' },
+    { key: 'lastName', value: 'bar' }
+  ];
   assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'should not rollback');
   assert.deepEqual(get(dummyChangeset, 'errors'), [], 'should rollback');
 });
@@ -900,6 +904,11 @@ test('#rollbackInvalid a specific key clears key error and keeps valid values', 
   assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'precondition');
   assert.deepEqual(get(dummyChangeset, 'errors'), expectedErrors, 'precondition');
   dummyChangeset.rollbackInvalid('name');
+  expectedChanges = [
+    { key: 'firstName', value: 'foo' },
+    { key: 'lastName', value: 'bar' },
+    { key: 'password', value: false }
+  ];
   assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'should not rollback');
   expectedErrors = [
     { key: 'password', validation: ['foo', 'bar'], value: false }
@@ -914,6 +923,25 @@ test('#rollbackInvalid resets valid state', function(assert) {
   assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
   dummyChangeset.rollbackInvalid();
   assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+});
+
+test('#rollbackInvalid works for keys not on changeset', function(assert) {
+  let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+  let expectedChanges = [
+    { key: 'firstName', value: 'foo' },
+    { key: 'lastName', value: 'bar' },
+    { key: 'name', value: '' }
+  ];
+  let expectedErrors = [{ key: 'name', validation: 'too short', value: '' }];
+  dummyChangeset.set('firstName', 'foo');
+  dummyChangeset.set('lastName', 'bar');
+  dummyChangeset.set('name', '');
+
+  assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'precondition');
+  assert.deepEqual(get(dummyChangeset, 'errors'), expectedErrors, 'precondition');
+  dummyChangeset.rollbackInvalid('dowat?');
+  assert.deepEqual(get(dummyChangeset, 'changes'), expectedChanges, 'should not rollback');
+  assert.deepEqual(get(dummyChangeset, 'errors'), expectedErrors, 'precondition');
 });
 
 test('#rollbackProperty restores old value for specified property only', function(assert) {


### PR DESCRIPTION
I haven't investigated the implications of this change; however, this is what it would look like.  Note - there are still tests that `execute` and do not apply those changes if invalid.  

I'm not sure if there is historical reasons for this or if simply was a design decision.

This also might require more information in the README.

Ref #297 
https://github.com/poteto/ember-changeset/issues/297#issuecomment-400101621