### PR TITLE
Fix typo in documentation for the `merge` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ changesetC.execute();
 
 user.get('firstName'); // "Jimmy"
 user.get('lastName'); // "Fallon"
-user.get('address.city'); // "10112"
+user.get('address.zipCode'); // "10112"
 ```
 
 Note that both changesets `A` and `B` are not destroyed by the merge, so you might want to call `destroy()` on them to avoid memory leaks.


### PR DESCRIPTION
## Changes proposed in this pull request
There was a small typo in the docs for the `merge` method and this fixes it