### PR TITLE
Do not clear changes after pushErrors

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -537,7 +537,6 @@ export function changeset(
       validation = [...v, ...newErrors];
 
       let c = (this /*: ChangesetDef */)
-      c._deleteKey(CHANGES, key);
       c.notifyPropertyChange(ERRORS);
       c.notifyPropertyChange(key);
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -516,8 +516,7 @@ export function changeset(
     },
 
     /**
-     * Manually push multiple errors to the changeset as an array. If there is
-     * an existing error or change for `key`, it will be overwritten.
+     * Manually push multiple errors to the changeset as an array.
      */
     pushErrors(
       key          /*: string        */,

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1292,7 +1292,7 @@ module('Unit | Utility | changeset', function(hooks) {
     assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
     assert.deepEqual(get(dummyChangeset, 'error.email.validation'), ['Email already taken', 'Invalid email format'], 'should push the error');
     assert.equal(get(dummyChangeset, 'error.email.value'), 'jim@bob.com', 'pushErrors uses already present value');
-    assert.deepEqual(get(dummyChangeset, 'changes'), [], 'pushErrors clears the changes on the changeset');
+    assert.deepEqual(get(dummyChangeset, 'changes'), [{ key: 'email', value: 'jim@bob.com' }], 'pushErrors does not clear the changes on the changeset');
     dummyChangeset.set('email', 'unique@email.com');
     assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
     assert.deepEqual(get(dummyChangeset, 'changes')[0], { key: 'email', value: 'unique@email.com' }, 'has correct changes');


### PR DESCRIPTION
I'm not totally sure why `CHANGES` are cleared when manually pushing an error clears the changes, resulting in dirty state to reset, but this PR removes that

close #177 