### PR TITLE
Add changeset-get helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,15 @@ In the above example, when the input changes, only the changeset's internal valu
 
 On rollback, all changes are dropped and the underlying Object is left untouched.
 
-## Changeset template helper
-`ember-changeset` overrides `set` in order to handle deeply nested setters.  `mut` is simply an alias for `set(changeset`, thus we provide a `changeset-set` template helper if you are dealing with nested setters.
+## Changeset template helpers
+`ember-changeset` overrides `set` and `get` in order to handle deeply nested setters.  `mut` is simply an alias for `set(changeset`, thus we provide a `changeset-set` template helper if you are dealing with nested setters. Additionally, `{{get changeset` is an alias for `get(changeset`, and so a `changeset-get` template helper is provided to deal with retrieving deeply nested properties.
 
 ```hbs
 <form>
   <input
     id="first-name"
     type="text"
-    value={{changeset.person.firstName}}
+    value={{changeset-get changeset "person.firstname"}}
     onchange={{action (changeset-set changeset "person.firstName") value="target.value"}}>
 </form>
 ```

--- a/addon/helpers/changeset-get.ts
+++ b/addon/helpers/changeset-get.ts
@@ -1,9 +1,9 @@
-import Helper from "@ember/component/helper";
-import { observer } from "@ember/object";
-import { ChangesetDef } from "ember-changeset/types";
+import Helper from '@ember/component/helper';
+import { observer } from '@ember/object';
+import { ChangesetDef } from 'ember-changeset/types';
 
-const CONTENT = "_content";
-const CHANGES = "_changes";
+const CONTENT = '_content';
+const CHANGES = '_changes';
 
 export default class ChangesetGet extends Helper.extend({
   invalidate: observer(`changeset.${CONTENT}`, `changeset.${CHANGES}`, function(
@@ -17,12 +17,12 @@ export default class ChangesetGet extends Helper.extend({
   init() {
     // @ts-ignore
     super.init(...arguments);
-    this.set("changeset", null);
+    this.set('changeset', null);
   }
 
   compute(this: ChangesetGet, [changeset, fieldPath]: [ChangesetDef, string]) {
     if (this.changeset === null) {
-      this.set("changeset", changeset);
+      this.set('changeset', changeset);
     }
 
     if (!this.changeset) {

--- a/addon/helpers/changeset-get.ts
+++ b/addon/helpers/changeset-get.ts
@@ -1,0 +1,33 @@
+import Helper from '@ember/component/helper';
+import { observer } from '@ember/object'
+import { ChangesetDef } from 'ember-changeset/types';
+
+const CONTENT = '_content';
+const CHANGES = '_changes';
+
+export default class ChangesetGet extends Helper.extend({
+  invalidate: observer(`changeset.${CONTENT}`, `changeset.${CHANGES}`, function(this: ChangesetGet) {
+    this.recompute();
+  }),
+
+}) {
+  changeset: ChangesetDef | null = null;
+
+  init() {
+    // @ts-ignore
+    super.init(...arguments);
+    this.set('changeset', null)
+  }
+
+  compute(this: ChangesetGet, [changeset, fieldPath]: [ChangesetDef, string]) {
+    if (this.changeset === null) {
+      this.set('changeset', changeset);
+    }
+
+    if (!this.changeset) {
+      return;
+    }
+
+    return this.changeset.get(fieldPath)
+  }
+}

--- a/addon/helpers/changeset-get.ts
+++ b/addon/helpers/changeset-get.ts
@@ -1,33 +1,34 @@
-import Helper from '@ember/component/helper';
-import { observer } from '@ember/object'
-import { ChangesetDef } from 'ember-changeset/types';
+import Helper from "@ember/component/helper";
+import { observer } from "@ember/object";
+import { ChangesetDef } from "ember-changeset/types";
 
-const CONTENT = '_content';
-const CHANGES = '_changes';
+const CONTENT = "_content";
+const CHANGES = "_changes";
 
 export default class ChangesetGet extends Helper.extend({
-  invalidate: observer(`changeset.${CONTENT}`, `changeset.${CHANGES}`, function(this: ChangesetGet) {
+  invalidate: observer(`changeset.${CONTENT}`, `changeset.${CHANGES}`, function(
+    this: ChangesetGet
+  ) {
     this.recompute();
-  }),
-
+  })
 }) {
   changeset: ChangesetDef | null = null;
 
   init() {
     // @ts-ignore
     super.init(...arguments);
-    this.set('changeset', null)
+    this.set("changeset", null);
   }
 
   compute(this: ChangesetGet, [changeset, fieldPath]: [ChangesetDef, string]) {
     if (this.changeset === null) {
-      this.set('changeset', changeset);
+      this.set("changeset", changeset);
     }
 
     if (!this.changeset) {
       return;
     }
 
-    return this.changeset.get(fieldPath)
+    return this.changeset.get(fieldPath);
   }
 }

--- a/addon/helpers/changeset-get.ts
+++ b/addon/helpers/changeset-get.ts
@@ -14,12 +14,6 @@ export default class ChangesetGet extends Helper.extend({
 }) {
   changeset: ChangesetDef | null = null;
 
-  init() {
-    // @ts-ignore
-    super.init(...arguments);
-    this.set('changeset', null);
-  }
-
   compute(this: ChangesetGet, [changeset, fieldPath]: [ChangesetDef, string]) {
     if (this.changeset === null) {
       this.set('changeset', changeset);

--- a/app/helpers/changeset-get.js
+++ b/app/helpers/changeset-get.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-changeset/helpers/changeset-get';

--- a/tests/integration/helpers/changeset-get-test.ts
+++ b/tests/integration/helpers/changeset-get-test.ts
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | changeset-get', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{changeset-get inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});

--- a/tests/integration/helpers/changeset-get-test.ts
+++ b/tests/integration/helpers/changeset-get-test.ts
@@ -1,12 +1,12 @@
-import { module, test } from "qunit";
-import { setupRenderingTest } from "ember-qunit";
-import { fillIn, find, settled, render } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { fillIn, find, settled, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
 
-import Changeset from "ember-changeset";
-import { run } from "@ember/runloop";
+import Changeset from 'ember-changeset';
+import { run } from '@ember/runloop';
 
-import { TestContext } from "ember-test-helpers";
+import { TestContext } from 'ember-test-helpers';
 
 interface ModelType {
   name: { first: string; last: string };
@@ -14,7 +14,7 @@ interface ModelType {
   url: string;
 }
 
-module("Integration | Helper | changeset-get", function(hooks) {
+module('Integration | Helper | changeset-get', function(hooks) {
   setupRenderingTest(hooks);
 
   let model: ModelType;
@@ -22,18 +22,18 @@ module("Integration | Helper | changeset-get", function(hooks) {
   hooks.beforeEach(function(this: TestContext) {
     model = {
       name: {
-        first: "Bob",
-        last: "Loblaw"
+        first: 'Bob',
+        last: 'Loblaw'
       },
-      email: "bob@lob.law",
-      url: "http://bobloblawslawblog.com"
+      email: 'bob@lob.law',
+      url: 'http://bobloblawslawblog.com'
     };
 
-    this.set("changeset", new Changeset(model));
-    this.set("fieldName", "name.first");
+    this.set('changeset', new Changeset(model));
+    this.set('fieldName', 'name.first');
   });
 
-  test("it fails to retrieve the current value using {{get}}", async function(assert) {
+  test('it fails to retrieve the current value using {{get}}', async function(assert) {
     await render(hbs`
       <input
         type="text"
@@ -49,25 +49,25 @@ module("Integration | Helper | changeset-get", function(hooks) {
       </ul>
     `);
 
-    const input = find("input") as HTMLInputElement;
-    const testEl = find("#test-el");
+    const input = find('input') as HTMLInputElement;
+    const testEl = find('#test-el');
 
     try {
-      await fillIn(input!, "Robert");
+      await fillIn(input!, 'Robert');
 
-      assert.equal(testEl!.textContent, "Bob");
+      assert.equal(testEl!.textContent, 'Bob');
 
       run(() => {
-        this.get("changeset").rollback();
+        this.get('changeset').rollback();
       });
 
-      assert.equal(testEl!.textContent, "Bob");
+      assert.equal(testEl!.textContent, 'Bob');
     } catch (e) {
       assert.ok(false, e.message);
     }
   });
 
-  test("it succeeds in retrieving the current value using {{changeset-get}}", async function(assert) {
+  test('it succeeds in retrieving the current value using {{changeset-get}}', async function(assert) {
     await render(hbs`
       <input
         type="text"
@@ -83,19 +83,19 @@ module("Integration | Helper | changeset-get", function(hooks) {
       </ul>
     `);
 
-    const input = find("input") as HTMLInputElement;
-    const testEl = find("#test-el");
+    const input = find('input') as HTMLInputElement;
+    const testEl = find('#test-el');
 
     try {
-      await fillIn(input!, "Robert");
+      await fillIn(input!, 'Robert');
 
-      assert.equal(testEl!.textContent, "Robert");
+      assert.equal(testEl!.textContent, 'Robert');
 
       run(() => {
-        this.get("changeset").rollback();
+        this.get('changeset').rollback();
       });
 
-      assert.equal(testEl!.textContent, "Bob");
+      assert.equal(testEl!.textContent, 'Bob');
     } catch (e) {
       assert.ok(false, e.message);
     }

--- a/tests/integration/helpers/changeset-get-test.ts
+++ b/tests/integration/helpers/changeset-get-test.ts
@@ -1,12 +1,11 @@
-import { module, test } from 'qunit';
+import { fillIn, find, render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn, find, settled, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
-
-import Changeset from 'ember-changeset';
-import { run } from '@ember/runloop';
-
 import { TestContext } from 'ember-test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+import { run } from '@ember/runloop';
+import Changeset from 'ember-changeset';
 
 interface ModelType {
   name: { first: string; last: string };

--- a/tests/integration/helpers/changeset-get-test.ts
+++ b/tests/integration/helpers/changeset-get-test.ts
@@ -1,17 +1,103 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { fillIn, find, settled, render } from "@ember/test-helpers";
+import hbs from "htmlbars-inline-precompile";
 
-module('Integration | Helper | changeset-get', function(hooks) {
+import Changeset from "ember-changeset";
+import { run } from "@ember/runloop";
+
+import { TestContext } from "ember-test-helpers";
+
+interface ModelType {
+  name: { first: string; last: string };
+  email: string;
+  url: string;
+}
+
+module("Integration | Helper | changeset-get", function(hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
-  test('it renders', async function(assert) {
-    this.set('inputValue', '1234');
+  let model: ModelType;
 
-    await render(hbs`{{changeset-get inputValue}}`);
+  hooks.beforeEach(function(this: TestContext) {
+    model = {
+      name: {
+        first: "Bob",
+        last: "Loblaw"
+      },
+      email: "bob@lob.law",
+      url: "http://bobloblawslawblog.com"
+    };
 
-    assert.equal(this.element.textContent.trim(), '1234');
+    this.set("changeset", new Changeset(model));
+    this.set("fieldName", "name.first");
+  });
+
+  test("it fails to retrieve the current value using {{get}}", async function(assert) {
+    await render(hbs`
+      <input
+        type="text"
+        oninput={{action (changeset-set changeset fieldName) value="target.value"}}
+        onchange={{action (changeset-set changeset fieldName) value="target.value"}}
+        value={{changeset-get changeset fieldName}}
+      />
+      <p id="test-el">{{get changeset fieldName}}</p>
+      <ul>
+        {{#each (get changeset "changes") as |change|}}
+          <li>{{change.key}}: {{change.value}}</li>
+        {{/each}}
+      </ul>
+    `);
+
+    const input = find("input") as HTMLInputElement;
+    const testEl = find("#test-el");
+
+    try {
+      await fillIn(input!, "Robert");
+
+      assert.equal(testEl!.textContent, "Bob");
+
+      run(() => {
+        this.get("changeset").rollback();
+      });
+
+      assert.equal(testEl!.textContent, "Bob");
+    } catch (e) {
+      assert.ok(false, e.message);
+    }
+  });
+
+  test("it succeeds in retrieving the current value using {{changeset-get}}", async function(assert) {
+    await render(hbs`
+      <input
+        type="text"
+        oninput={{action (changeset-set changeset fieldName) value="target.value"}}
+        onchange={{action (changeset-set changeset fieldName) value="target.value"}}
+        value={{changeset-get changeset fieldName}}
+      />
+      <p id="test-el">{{changeset-get changeset fieldName}}</p>
+      <ul>
+        {{#each (get changeset "changes") as |change|}}
+          <li>{{change.key}}: {{change.value}}</li>
+        {{/each}}
+      </ul>
+    `);
+
+    const input = find("input") as HTMLInputElement;
+    const testEl = find("#test-el");
+
+    try {
+      await fillIn(input!, "Robert");
+
+      assert.equal(testEl!.textContent, "Robert");
+
+      run(() => {
+        this.get("changeset").rollback();
+      });
+
+      assert.equal(testEl!.textContent, "Bob");
+    } catch (e) {
+      assert.ok(false, e.message);
+    }
   });
 });


### PR DESCRIPTION
This adds a new helper: `changeset-get` that allow us to get a value from template using dynamic field name with nested path. 

This closes #342 as it adds a way to go around the problem.

A working example of this helper can be found here: https://github.com/neighborly/changeset-test/pull/1

@jasonmevans Do you mind finishing up this PR?

 - [x] Add tests.
 - [x] Add documentation for the changes we made.
