### PR TITLE
Fix validationMap type signature

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -78,7 +78,7 @@ const defaultOptions = { skipValidate: false };
 export function changeset(
   obj: object,
   validateFn: ValidatorFunc = defaultValidatorFn,
-  validationMap: { [s: string]: ValidatorFunc } = {},
+  validationMap: { [s: string]: ValidatorFunc | ValidatorFunc[] } = {},
   options: Config = {}
 ) {
   assert('Underlying object for changeset is missing', isPresent(obj));
@@ -785,7 +785,7 @@ export default class Changeset {
   constructor(
     obj: object,
     validateFn: ValidatorFunc = defaultValidatorFn,
-    validationMap: { [s: string]: ValidatorFunc } = {},
+    validationMap: { [s: string]: ValidatorFunc | ValidatorFunc[] } = {},
     options: Config = {}
   ) {
     return changeset(obj, validateFn, validationMap, options).create();


### PR DESCRIPTION
## Changes proposed in this pull request
At the moment Typescript complication fails if the validationMap is an object with arrays as values, which [valid syntax](https://github.com/poteto/ember-changeset-validations#usage).

E.g.

```
export default {
  firstName: [
    validatePresence(true),
    validateLength({ min: 4 })
  ]
}
```

This change fixes the compilation error.