### PR TITLE
Fix push errors to update error property pr

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -438,11 +438,12 @@ export function changeset(
 
       let v = existingError.validation;
       validation = [...v, ...newErrors];
+      let newError = new Err(value, validation);
+      setNestedProperty(errors, (<string>key), newError);
 
       this.notifyPropertyChange(ERRORS);
       this.notifyPropertyChange((<string>key));
 
-      errors[key] = new Err(value, validation);
       return { value, validation };
     },
 


### PR DESCRIPTION
## Changes proposed in this pull request

I found that I was having trouble binding to `errors.<someField>.validation` in a template without using `setNestedProperty` - I added some tests and made sure that `pushErrors` uses `setNestedProperty` like `addError` does