### PR TITLE
Getting nested value in error value using `Changeset#get` should work

### DIFF
--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -329,6 +329,14 @@ module('Unit | Utility | changeset', function(hooks) {
     }
   });
 
+  test('can get nested values in the error object', function(assert) {
+    let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+    let expectedResult = { validation: 'too short', value: 'a' };
+    dummyChangeset.set('name', 'a');
+
+    assert.deepEqual(dummyChangeset.get('error.name'), expectedResult, 'should return error object for `name` key');
+  });
+
   /**
    * #set
    */


### PR DESCRIPTION
In v1.6.0, it was possible to get a nested value from the `error` object by using `get` on an instance of Changeset:

```js
changeset.get('error.name')
```

This returned `undefined` if it wasn't present, and an object with the `value` and `validation` if it was.

This is not possible in the newest version - it instead returns `undefined` no matter what.

By using `git bisect` with this test, I found that this stopped working in `v2.0.0-beta.0`.

I don't know what the intended behavior here is now, but it seems to me like this at least _was_ intended to work.

For instance, there's an example in the README that uses this too, which also fails since 2.0: https://github.com/poteto/ember-changeset/blob/3d777266a252d352513c6833fe3fc83345da9c90/README.md#tips-and-tricks

This always returns `undefined` and sets `hasError` to `false`:

```js
    if (!changeset.get(`error.${valuePath}`)) {
      set(this, 'hasError', false);
    } else {
      // if error, restore changeset so don't show error in template immediately'
      // i.e. wait for onblur action to validate and show error in template
      changeset.restore(snapshot);
    }
```

The alternative to making this work again is to instead use normal getters:

```js
// no
changeset.get('error.name')

// yes
changeset.error.name
```

You could even say this is preferable, I'm merely saying that it used to work and now it doesn't.