### PR TITLE
[Minor]: Allow changeset to accept validation map

### DIFF
--- a/addon/helpers/changeset.ts
+++ b/addon/helpers/changeset.ts
@@ -1,23 +1,33 @@
 import { helper } from '@ember/component/helper';
 import Changeset from 'ember-changeset';
 import { Config } from 'ember-changeset/types/config';
-import { ValidatorFunc } from 'ember-changeset/types/validator-func';
+import { ValidatorFunc, ValidatorMap } from 'ember-changeset/types/validator-func';
+import lookupValidator from 'ember-changeset/utils/validator-lookup';
 import isChangeset from 'ember-changeset/utils/is-changeset';
 import isPromise from 'ember-changeset/utils/is-promise';
+import isObject from 'ember-changeset/utils/is-object';
 
 export function changeset(
-  [obj, validations]: [object | Promise<any>, ValidatorFunc],
+  [obj, validations]: [object | Promise<any>, ValidatorFunc | ValidatorMap],
   options: Config = {}
 ): Changeset | Promise<Changeset> {
   if (isChangeset(obj)) {
     return obj;
   }
 
-  if (isPromise(obj)) {
-    return Promise.resolve(obj).then((resolved: any) => new Changeset(resolved, validations, {}, options));
+  if (isObject(validations)) {
+    if (isPromise(obj)) {
+      return (<Promise<any>>obj).then((resolved) => new Changeset(resolved, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options));
+    }
+
+    return new Changeset(obj, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options);
   }
 
-  return new Changeset(obj, validations, {}, options);
+  if (isPromise(obj)) {
+    return Promise.resolve(obj).then((resolved: any) => new Changeset(resolved, <ValidatorFunc>validations, {}, options));
+  }
+
+  return new Changeset(obj, <ValidatorFunc>validations, {}, options);
 }
 
 export default helper(changeset);

--- a/addon/helpers/changeset.ts
+++ b/addon/helpers/changeset.ts
@@ -17,7 +17,9 @@ export function changeset(
 
   if (isObject(validations)) {
     if (isPromise(obj)) {
-      return (<Promise<any>>obj).then((resolved) => new Changeset(resolved, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options));
+      return (<Promise<any>>obj).then((resolved) =>
+        new Changeset(resolved, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options)
+      );
     }
 
     return new Changeset(obj, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options);

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -55,6 +55,7 @@ import {
   ValidationErr,
   ValidationResult,
   ValidatorFunc,
+  ValidatorMap
 } from 'ember-changeset/types';
 
 const { keys } = Object;
@@ -78,7 +79,7 @@ const defaultOptions = { skipValidate: false };
 export function changeset(
   obj: object,
   validateFn: ValidatorFunc = defaultValidatorFn,
-  validationMap: { [s: string]: ValidatorFunc | ValidatorFunc[] } = {},
+  validationMap: ValidatorMap = {},
   options: Config = {}
 ) {
   assert('Underlying object for changeset is missing', isPresent(obj));
@@ -605,8 +606,8 @@ export function changeset(
      */
     _validate(
       key: string,
-      newValue: any,
-      oldValue: any
+      newValue: unknown,
+      oldValue: unknown
     ): ValidationResult | Promise<ValidationResult> {
       let validator: ValidatorFunc = get(this, VALIDATOR);
       let content: Content = get(this, CONTENT);
@@ -784,7 +785,7 @@ export default class Changeset {
   constructor(
     obj: object,
     validateFn: ValidatorFunc = defaultValidatorFn,
-    validationMap: { [s: string]: ValidatorFunc | ValidatorFunc[] } = {},
+    validationMap: ValidatorMap = {},
     options: Config = {}
   ) {
     return changeset(obj, validateFn, validationMap, options).create();

--- a/addon/types/index.ts
+++ b/addon/types/index.ts
@@ -2,9 +2,9 @@ import {
   ValidationErr,
   ValidationResult,
 } from 'ember-changeset/types/validation-result';
-import { ValidatorFunc } from 'ember-changeset/types/validator-func';
+import { ValidatorFunc, ValidatorMap } from 'ember-changeset/types/validator-func';
 
-export { ValidatorFunc };
+export { ValidatorFunc, ValidatorMap };
 export { ValidationErr, ValidationResult };
 import { Config } from 'ember-changeset/types/config';
 export { Config };

--- a/addon/types/validator-func.ts
+++ b/addon/types/validator-func.ts
@@ -3,9 +3,11 @@ import { ValidationResult } from 'ember-changeset/types/validation-result';
 export type ValidatorFunc = {
   (params: {
     key: string,
-    newValue: any,
-    oldValue: any,
-    changes: { [key: string]: any },
+    newValue: unknown,
+    oldValue: unknown,
+    changes: { [key: string]: unknown },
     content: object
   }): ValidationResult | Promise<ValidationResult>;
 }
+
+export type ValidatorMap = { [s: string]: ValidatorFunc | ValidatorFunc[] };

--- a/addon/utils/computed/inflate.ts
+++ b/addon/utils/computed/inflate.ts
@@ -1,5 +1,6 @@
 import { assert, runInDebug } from '@ember/debug';
 import { computed, get } from '@ember/object';
+import ComputedProperty from '@ember/object/computed';
 import { isBlank } from '@ember/utils';
 import isObject from 'ember-changeset/utils/is-object';
 import deepSet from 'ember-deep-set';
@@ -13,7 +14,7 @@ const { keys } = Object;
 export default function inflate<T>(
   dependentKey: string,
   transform: (arg: T) => any = a => a
-): { [key: string]: any } {
+): ComputedProperty<{}, {}> {
   return computed(dependentKey, function() {
     let obj: { [key: string]: any } = get(this, dependentKey);
 

--- a/addon/utils/computed/is-empty-object.ts
+++ b/addon/utils/computed/is-empty-object.ts
@@ -7,7 +7,7 @@ const { keys } = Object;
 
 export default function isEmptyObject(
   dependentKey: string
-): ComputedProperty<boolean, boolean> {
+): ComputedProperty<{}, {}> {
   assert('`dependentKey` must be defined', isPresent(dependentKey));
 
   return computed(dependentKey, function() {

--- a/addon/utils/computed/object-equal.ts
+++ b/addon/utils/computed/object-equal.ts
@@ -17,7 +17,7 @@ const { keys } = Object;
 export default function objectEqual(
   sourceKey: string,
   compareKey: string
-): ComputedProperty<boolean, boolean> {
+): ComputedProperty<{}, {}> {
   return computed(sourceKey, compareKey, function() {
     let source = get(this, sourceKey);
     let compare = get(this, compareKey);

--- a/addon/utils/computed/transform.ts
+++ b/addon/utils/computed/transform.ts
@@ -1,4 +1,5 @@
 import { computed, get } from '@ember/object';
+import ComputedProperty from '@ember/object/computed';
 
 const { keys } = Object;
 
@@ -8,7 +9,7 @@ const { keys } = Object;
 export default function transform<T>(
   dependentKey: string,
   transform: (arg: T) => any
-): object {
+): ComputedProperty<{}, {}> {
   return computed(dependentKey, function() {
     let obj: { [key: string]: any } = get(this, dependentKey);
     return keys(obj).reduce((newObj: { [key: string]: any }, key: string) => {

--- a/addon/utils/handle-multiple-validations.ts
+++ b/addon/utils/handle-multiple-validations.ts
@@ -37,8 +37,10 @@ export default function handleMultipleValidations(
   { key, newValue, oldValue, changes, content }: { [s: string]: any }
 ): Boolean | any {
   let validations: Array<ValidationResult | Promise<ValidationResult>> = emberArray(
-    validators.map((validator: ValidatorFunc): ValidationResult | Promise<ValidationResult> => validator({ key, newValue, oldValue, changes, content })
-  ));
+    validators.map((validator: ValidatorFunc): ValidationResult | Promise<ValidationResult> =>
+      validator({ key, newValue, oldValue, changes, content })
+    )
+  );
 
   if (emberArray(validations).any(isPromise)) {
     return all(validations).then(handleValidations);

--- a/addon/utils/handle-multiple-validations.ts
+++ b/addon/utils/handle-multiple-validations.ts
@@ -1,0 +1,49 @@
+import { A as emberArray } from '@ember/array';
+import { all } from 'rsvp';
+import { get } from '@ember/object';
+import isPromise from 'ember-changeset/utils/is-promise';
+import { ValidatorFunc, ValidationResult } from 'ember-changeset/types';
+
+/**
+ * Rejects `true` values from an array of validations. Returns `true` when there
+ * are no errors, or the error object if there are errors.
+ *
+ * @private
+ * @param  {Array} validations
+ * @return {Boolean|Any}
+ */
+function handleValidations(validations: Array<ValidationResult | Promise<ValidationResult>>): Boolean | any {
+  let rejectedValidations = emberArray(validations)
+    .reject((validation) => typeof validation === 'boolean' && validation);
+
+  return get(rejectedValidations, 'length') === 0 || rejectedValidations;
+}
+
+/**
+ * Handles an array of validators and returns Promise.all if any value is a
+ * Promise.
+ *
+ * @public
+ * @param  {Array} validators Array of validator functions
+ * @param  {String} options.key
+ * @param  {Any} options.newValue
+ * @param  {Any} options.oldValue
+ * @param  {Object} options.changes
+ * @param  {Object} options.content
+ * @return {Promise|Boolean|Any}
+ */
+export default function handleMultipleValidations(
+  validators: ValidatorFunc[],
+  { key, newValue, oldValue, changes, content }: { [s: string]: any }
+): Boolean | any {
+  let validations: Array<ValidationResult | Promise<ValidationResult>> = emberArray(
+    validators.map((validator: ValidatorFunc): ValidationResult | Promise<ValidationResult> => validator({ key, newValue, oldValue, changes, content })
+  ));
+
+  if (emberArray(validations).any(isPromise)) {
+    return all(validations).then(handleValidations);
+  }
+
+  return handleValidations(validations);
+}
+

--- a/addon/utils/handle-multiple-validations.ts
+++ b/addon/utils/handle-multiple-validations.ts
@@ -1,5 +1,5 @@
 import { A as emberArray } from '@ember/array';
-import { all } from 'rsvp';
+import { all, reject } from 'rsvp';
 import { get } from '@ember/object';
 import isPromise from 'ember-changeset/utils/is-promise';
 import { ValidatorFunc, ValidationResult } from 'ember-changeset/types';
@@ -13,10 +13,10 @@ import { ValidatorFunc, ValidationResult } from 'ember-changeset/types';
  * @return {Boolean|Any}
  */
 function handleValidations(validations: Array<ValidationResult | Promise<ValidationResult>>): Boolean | any {
-  let rejectedValidations = emberArray(validations)
+  let maybeRejected = emberArray(validations)
     .reject((validation) => typeof validation === 'boolean' && validation);
 
-  return get(rejectedValidations, 'length') === 0 || rejectedValidations;
+  return get(maybeRejected, 'length') === 0 || maybeRejected;
 }
 
 /**

--- a/addon/utils/handle-multiple-validations.ts
+++ b/addon/utils/handle-multiple-validations.ts
@@ -1,5 +1,5 @@
 import { A as emberArray } from '@ember/array';
-import { all, reject } from 'rsvp';
+import { all } from 'rsvp';
 import { get } from '@ember/object';
 import isPromise from 'ember-changeset/utils/is-promise';
 import { ValidatorFunc, ValidationResult } from 'ember-changeset/types';

--- a/addon/utils/validator-lookup.ts
+++ b/addon/utils/validator-lookup.ts
@@ -1,0 +1,25 @@
+import { isEmpty } from '@ember/utils';
+import { isArray } from '@ember/array';
+import wrapInArray from 'ember-changeset/utils/wrap';
+import handleMultipleValidations from 'ember-changeset/utils/handle-multiple-validations';
+import isPromise from 'ember-changeset/utils/is-promise';
+import { ValidatorFunc, ValidationResult, ValidatorMap } from 'ember-changeset/types';
+
+export default function lookupValidator(validationMap: ValidatorMap): ValidatorFunc {
+  return ({ key, newValue, oldValue, changes, content }) => {
+    let validator: ValidatorFunc | ValidatorFunc[] = validationMap[key];
+
+    if (isEmpty(validator)) {
+      return true;
+    }
+
+    if (isArray(validator)) {
+      return handleMultipleValidations(<ValidatorFunc[]>validator, { key, newValue, oldValue, changes, content });
+    }
+
+    let validation: ValidationResult | Promise<ValidationResult> = (<ValidatorFunc>validator)({ key, newValue, oldValue, changes, content });
+
+    return isPromise(validation) ? (<Promise<ValidationResult>>validation).then(wrapInArray) : [validation];
+  };
+}
+

--- a/addon/utils/validator-lookup.ts
+++ b/addon/utils/validator-lookup.ts
@@ -5,6 +5,12 @@ import handleMultipleValidations from 'ember-changeset/utils/handle-multiple-val
 import isPromise from 'ember-changeset/utils/is-promise';
 import { ValidatorFunc, ValidationResult, ValidatorMap } from 'ember-changeset/types';
 
+/**
+ * returns a closure to lookup and validate k/v pairs set on a changeset
+ *
+ * @method lookupValidator
+ * @param validationMap
+ */
 export default function lookupValidator(validationMap: ValidatorMap): ValidatorFunc {
   return ({ key, newValue, oldValue, changes, content }) => {
     let validator: ValidatorFunc | ValidatorFunc[] = validationMap[key];

--- a/addon/utils/wrap.ts
+++ b/addon/utils/wrap.ts
@@ -1,0 +1,17 @@
+import { isArray, A as emberArray } from '@ember/array';
+
+/**
+ * Wraps a value in an Ember.Array.
+ *
+ * @public
+ * @param  {Any} value
+ * @return {Ember.Array}
+ */
+export default function wrapInArray<T>(value: T | T[]): T[] {
+  if (isArray(value)) {
+    return emberArray(value);
+  }
+
+  return emberArray([value]);
+}
+

--- a/tests/integration/components/changeset-test.js
+++ b/tests/integration/components/changeset-test.js
@@ -56,6 +56,40 @@ module('Integration | Helper | changeset', function(hooks) {
     assert.notOk(find('#errors-paragraph'), 'should be valid');
   });
 
+  test('it accepts validation map', async function(assert) {
+    let validations = {
+      firstName({ newValue: value }) {
+        return isPresent(value) && value.length > 3 || 'too short';
+      },
+      lastName({ newValue: value }) {
+        return isPresent(value) && value.length > 3 || 'too short';
+      }
+    };
+    this.set('dummyModel', { firstName: 'Jim', lastName: 'Bobbie' });
+    this.set('validations', validations);
+    this.set('submit', (changeset) => changeset.validate());
+    this.set('reset', (changeset) => changeset.rollback());
+    await render(hbs`
+      {{#with (changeset dummyModel validations) as |changesetObj|}}
+        {{#if changesetObj.isInvalid}}
+          <p id="errors-paragraph">There were one or more errors in your form.</p>
+        {{/if}}
+        {{input id="first-name" value=changesetObj.firstName}}
+        {{input id="last-name" value=changesetObj.lastName}}
+        <button id="submit-btn" {{action submit changesetObj}}>Submit</button>
+        <button id="reset-btn" {{action reset changesetObj}}>Reset</button>
+      {{/with}}
+    `);
+
+    await fillIn('#first-name', 'A');
+    await click('#submit-btn');
+    assert.ok(find('#errors-paragraph'), 'should be invalid');
+
+    await fillIn('#first-name', 'Billy');
+    await click('#submit-btn');
+    assert.notOk(find('#errors-paragraph'), 'should be valid');
+  });
+
   test('it rollsback changes', async function(assert) {
     this.set('dummyModel', { firstName: 'Jim' });
     this.set('reset', (changeset) => changeset.rollback());

--- a/tests/integration/components/changeset-test.js
+++ b/tests/integration/components/changeset-test.js
@@ -90,6 +90,44 @@ module('Integration | Helper | changeset', function(hooks) {
     assert.notOk(find('#errors-paragraph'), 'should be valid');
   });
 
+  test('it accepts validation map with multiple validations', async function(assert) {
+    function validateLength() {
+      return ({ newValue: value }) => isPresent(value) && value.length > 3 || 'too short';
+    }
+    function validateStartsUppercase() {
+      return ({ newValue: value }) => isPresent(value) && value.charCodeAt(0) > 65 && value.charCodeAt(0) < 90 || 'not upper case';
+    }
+    let validations = {
+      firstName: [
+        validateLength(),
+        validateStartsUppercase()
+      ]
+    };
+    this.set('dummyModel', { firstName: 'Jim', lastName: 'Bobbie' });
+    this.set('validations', validations);
+    this.set('submit', (changeset) => changeset.validate());
+    this.set('reset', (changeset) => changeset.rollback());
+    await render(hbs`
+      {{#with (changeset dummyModel validations) as |changesetObj|}}
+        {{#if changesetObj.isInvalid}}
+          <p id="errors-paragraph">There were one or more errors in your form.</p>
+        {{/if}}
+        {{input id="first-name" value=changesetObj.firstName}}
+        {{input id="last-name" value=changesetObj.lastName}}
+        <button id="submit-btn" {{action submit changesetObj}}>Submit</button>
+        <button id="reset-btn" {{action reset changesetObj}}>Reset</button>
+      {{/with}}
+    `);
+
+    await fillIn('#first-name', 'A');
+    await click('#submit-btn');
+    assert.ok(find('#errors-paragraph'), 'should be invalid');
+
+    await fillIn('#first-name', 'Billy');
+    await click('#submit-btn');
+    assert.notOk(find('#errors-paragraph'), 'should be valid');
+  });
+
   test('it rollsback changes', async function(assert) {
     this.set('dummyModel', { firstName: 'Jim' });
     this.set('reset', (changeset) => changeset.rollback());


### PR DESCRIPTION
The idea here is to align the API of this changeset helper to the one found in `ember-changeset-validations` by accepting a `ValidationMap` and throwing a closure on top of it to lookup the specific validator function.

https://github.com/poteto/ember-changeset-validations/pull/198

close #371 