### PR TITLE
Ensure closure over validation map accepts objects first

### DIFF
--- a/addon/helpers/changeset.ts
+++ b/addon/helpers/changeset.ts
@@ -1,14 +1,14 @@
 import { helper } from '@ember/component/helper';
 import Changeset from 'ember-changeset';
 import { Config } from 'ember-changeset/types/config';
-import { ValidatorFunc, ValidatorMap } from 'ember-changeset/types/validator-func';
+import { ValidatorAction, ValidatorMap } from 'ember-changeset/types/validator-func';
 import lookupValidator from 'ember-changeset/utils/validator-lookup';
 import isChangeset from 'ember-changeset/utils/is-changeset';
 import isPromise from 'ember-changeset/utils/is-promise';
 import isObject from 'ember-changeset/utils/is-object';
 
 export function changeset(
-  [obj, validations]: [object | Promise<any>, ValidatorFunc | ValidatorMap],
+  [obj, validations]: [object | Promise<any>, ValidatorAction | ValidatorMap],
   options: Config = {}
 ): Changeset | Promise<Changeset> {
   if (isChangeset(obj)) {
@@ -26,10 +26,10 @@ export function changeset(
   }
 
   if (isPromise(obj)) {
-    return Promise.resolve(obj).then((resolved: any) => new Changeset(resolved, <ValidatorFunc>validations, {}, options));
+    return Promise.resolve(obj).then((resolved: any) => new Changeset(resolved, <ValidatorAction>validations, {}, options));
   }
 
-  return new Changeset(obj, <ValidatorFunc>validations, {}, options);
+  return new Changeset(obj, <ValidatorAction>validations, {}, options);
 }
 
 export default helper(changeset);

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -54,7 +54,7 @@ import {
   Snapshot,
   ValidationErr,
   ValidationResult,
-  ValidatorFunc,
+  ValidatorAction,
   ValidatorMap
 } from 'ember-changeset/types';
 
@@ -78,7 +78,7 @@ const defaultOptions = { skipValidate: false };
  */
 export function changeset(
   obj: object,
-  validateFn: ValidatorFunc = defaultValidatorFn,
+  validateFn: ValidatorAction = defaultValidatorFn,
   validationMap: ValidatorMap = {},
   options: Config = {}
 ) {
@@ -609,7 +609,7 @@ export function changeset(
       newValue: unknown,
       oldValue: unknown
     ): ValidationResult | Promise<ValidationResult> {
-      let validator: ValidatorFunc = get(this, VALIDATOR);
+      let validator: ValidatorAction = get(this, VALIDATOR);
       let content: Content = get(this, CONTENT);
 
       if (typeof validator === 'function') {
@@ -784,7 +784,7 @@ export default class Changeset {
    */
   constructor(
     obj: object,
-    validateFn: ValidatorFunc = defaultValidatorFn,
+    validateFn: ValidatorAction = defaultValidatorFn,
     validationMap: ValidatorMap = {},
     options: Config = {}
   ) {

--- a/addon/types/index.ts
+++ b/addon/types/index.ts
@@ -2,9 +2,9 @@ import {
   ValidationErr,
   ValidationResult,
 } from 'ember-changeset/types/validation-result';
-import { ValidatorFunc, ValidatorMap } from 'ember-changeset/types/validator-func';
+import { ValidatorAction, ValidatorMapFunc, ValidatorMap } from 'ember-changeset/types/validator-func';
 
-export { ValidatorFunc, ValidatorMap };
+export { ValidatorAction, ValidatorMapFunc, ValidatorMap };
 export { ValidationErr, ValidationResult };
 import { Config } from 'ember-changeset/types/config';
 export { Config };
@@ -73,7 +73,7 @@ export interface ChangesetDef extends Any {
   _content: object,
   _changes: Changes,
   _errors: Errors<any>,
-  _validator: ValidatorFunc,
+  _validator: ValidatorAction,
   _options: Config,
   _runningValidations: RunningValidations,
   _bareChanges: { [s: string]: any },

--- a/addon/types/validator-func.ts
+++ b/addon/types/validator-func.ts
@@ -1,6 +1,6 @@
 import { ValidationResult } from 'ember-changeset/types/validation-result';
 
-export type ValidatorFunc = {
+export type ValidatorAction = {
   (params: {
     key: string,
     newValue: unknown,
@@ -10,4 +10,14 @@ export type ValidatorFunc = {
   }): ValidationResult | Promise<ValidationResult>;
 }
 
-export type ValidatorMap = { [s: string]: ValidatorFunc | ValidatorFunc[] };
+export type ValidatorMapFunc = {
+  (
+    key: string,
+    newValue: unknown,
+    oldValue: unknown,
+    changes: { [key: string]: unknown },
+    content: object
+  ): ValidationResult | Promise<ValidationResult>;
+}
+
+export type ValidatorMap = { [s: string]: ValidatorMapFunc | ValidatorMapFunc[] };

--- a/addon/utils/handle-multiple-validations.ts
+++ b/addon/utils/handle-multiple-validations.ts
@@ -2,7 +2,7 @@ import { A as emberArray } from '@ember/array';
 import { all } from 'rsvp';
 import { get } from '@ember/object';
 import isPromise from 'ember-changeset/utils/is-promise';
-import { ValidatorFunc, ValidationResult } from 'ember-changeset/types';
+import { ValidatorMapFunc, ValidationResult } from 'ember-changeset/types';
 
 /**
  * Rejects `true` values from an array of validations. Returns `true` when there
@@ -33,12 +33,12 @@ function handleValidations(validations: Array<ValidationResult | Promise<Validat
  * @return {Promise|Boolean|Any}
  */
 export default function handleMultipleValidations(
-  validators: ValidatorFunc[],
+  validators: ValidatorMapFunc[],
   { key, newValue, oldValue, changes, content }: { [s: string]: any }
 ): Boolean | any {
   let validations: Array<ValidationResult | Promise<ValidationResult>> = emberArray(
-    validators.map((validator: ValidatorFunc): ValidationResult | Promise<ValidationResult> =>
-      validator({ key, newValue, oldValue, changes, content })
+    validators.map((validator: ValidatorMapFunc): ValidationResult | Promise<ValidationResult> =>
+      validator(key, newValue, oldValue, changes, content)
     )
   );
 

--- a/addon/utils/validator-lookup.ts
+++ b/addon/utils/validator-lookup.ts
@@ -3,7 +3,7 @@ import { isArray } from '@ember/array';
 import wrapInArray from 'ember-changeset/utils/wrap';
 import handleMultipleValidations from 'ember-changeset/utils/handle-multiple-validations';
 import isPromise from 'ember-changeset/utils/is-promise';
-import { ValidatorFunc, ValidationResult, ValidatorMap } from 'ember-changeset/types';
+import { ValidatorAction, ValidatorMapFunc, ValidationResult, ValidatorMap } from 'ember-changeset/types';
 
 /**
  * returns a closure to lookup and validate k/v pairs set on a changeset
@@ -11,19 +11,19 @@ import { ValidatorFunc, ValidationResult, ValidatorMap } from 'ember-changeset/t
  * @method lookupValidator
  * @param validationMap
  */
-export default function lookupValidator(validationMap: ValidatorMap): ValidatorFunc {
+export default function lookupValidator(validationMap: ValidatorMap): ValidatorAction {
   return ({ key, newValue, oldValue, changes, content }) => {
-    let validator: ValidatorFunc | ValidatorFunc[] = validationMap[key];
+    let validator: ValidatorMapFunc | ValidatorMapFunc[] = validationMap[key];
 
     if (isEmpty(validator)) {
       return true;
     }
 
     if (isArray(validator)) {
-      return handleMultipleValidations(<ValidatorFunc[]>validator, { key, newValue, oldValue, changes, content });
+      return handleMultipleValidations(<ValidatorMapFunc[]>validator, { key, newValue, oldValue, changes, content });
     }
 
-    let validation: ValidationResult | Promise<ValidationResult> = (<ValidatorFunc>validator)({ key, newValue, oldValue, changes, content });
+    let validation: ValidationResult | Promise<ValidationResult> = (<ValidatorMapFunc>validator)(key, newValue, oldValue, changes, content);
 
     return isPromise(validation) ? (<Promise<ValidationResult>>validation).then(wrapInArray) : [validation];
   };

--- a/tests/integration/components/changeset-test.js
+++ b/tests/integration/components/changeset-test.js
@@ -130,10 +130,10 @@ module('Integration | Helper | changeset', function(hooks) {
 
   test('it accepts validation map with multiple validations with promises', async function(assert) {
     function validateLength() {
-      return ({ newValue: value }) => isPresent(value) && Promise.resolve(value.length > 3) || 'too short';
+      return (key, newValue) => isPresent(newValue) && Promise.resolve(newValue.length > 3) || 'too short';
     }
     function validateStartsUppercase() {
-      return ({ newValue: value }) => isPresent(value) && value.charCodeAt(0) > 65 && value.charCodeAt(0) < 90 || Promise.resolve('not upper case');
+      return (key, newValue) => isPresent(newValue) && newValue.charCodeAt(0) > 65 && newValue.charCodeAt(0) < 90 || Promise.resolve('not upper case');
     }
     let validations = {
       firstName: [

--- a/tests/integration/components/changeset-test.js
+++ b/tests/integration/components/changeset-test.js
@@ -58,11 +58,11 @@ module('Integration | Helper | changeset', function(hooks) {
 
   test('it accepts validation map', async function(assert) {
     let validations = {
-      firstName({ newValue: value }) {
-        return isPresent(value) && value.length > 3 || 'too short';
+      firstName(key, newValue) {
+        return isPresent(newValue) && newValue.length > 3 || 'too short';
       },
-      lastName({ newValue: value }) {
-        return isPresent(value) && value.length > 3 || 'too short';
+      lastName(key, newValue) {
+        return isPresent(newValue) && newValue.length > 3 || 'too short';
       }
     };
     this.set('dummyModel', { firstName: 'Jim', lastName: 'Bobbie' });
@@ -92,10 +92,10 @@ module('Integration | Helper | changeset', function(hooks) {
 
   test('it accepts validation map with multiple validations', async function(assert) {
     function validateLength() {
-      return ({ newValue: value }) => isPresent(value) && value.length > 3 || 'too short';
+      return (key, newValue) => isPresent(newValue) && newValue.length > 3 || 'too short';
     }
     function validateStartsUppercase() {
-      return ({ newValue: value }) => isPresent(value) && value.charCodeAt(0) > 65 && value.charCodeAt(0) < 90 || 'not upper case';
+      return (key, newValue) => isPresent(newValue) && newValue.charCodeAt(0) > 65 && newValue.charCodeAt(0) < 90 || 'not upper case';
     }
     let validations = {
       firstName: [
@@ -130,10 +130,12 @@ module('Integration | Helper | changeset', function(hooks) {
 
   test('it accepts validation map with multiple validations with promises', async function(assert) {
     function validateLength() {
-      return (key, newValue) => isPresent(newValue) && Promise.resolve(newValue.length > 3) || 'too short';
+      return (key, newValue) =>
+        isPresent(newValue) && Promise.resolve(newValue.length > 3) || 'too short';
     }
     function validateStartsUppercase() {
-      return (key, newValue) => isPresent(newValue) && newValue.charCodeAt(0) > 65 && newValue.charCodeAt(0) < 90 || Promise.resolve('not upper case');
+      return (key, newValue) =>
+        isPresent(newValue) && newValue.charCodeAt(0) > 65 && newValue.charCodeAt(0) < 90 || Promise.resolve('not upper case');
     }
     let validations = {
       firstName: [


### PR DESCRIPTION
closure over ember-changeset-validations map needs to accept object of key, vaues and conent and then pass each individual key into the validator function

follow up https://github.com/poteto/ember-changeset/pull/372

Ref https://github.com/poteto/ember-changeset-validations/pull/198