### PR TITLE
allow multiple keys for .validate

### DIFF
--- a/addon/-private/validated-changeset.ts
+++ b/addon/-private/validated-changeset.ts
@@ -447,21 +447,19 @@ export class BufferedChangeset implements IChangeset {
    * @method validate
    */
   validate(
-    key?: string | undefined
+    ...validationKeys: string[]
   ): Promise<null> | Promise<any | IErr<any>> | Promise<Array<any | IErr<any>>> {
     if (keys(this.validationMap as object).length === 0) {
       return Promise.resolve(null);
     }
 
-    if (!Boolean(key)) {
-      let maybePromise = keys(this.validationMap as object).map(validationKey => {
-        return this._validateKey(validationKey, this._valueFor(validationKey));
-      });
+    validationKeys = validationKeys.length > 0 ? validationKeys : keys(this.validationMap as object);
 
-      return Promise.all(maybePromise);
-    }
+    let maybePromise = validationKeys.map((key) => {
+      return this._validateKey(<string>key, this._valueFor(<string>key))
+    });
 
-    return Promise.resolve(this._validateKey(<string>key, this._valueFor(<string>key)));
+    return Promise.all(maybePromise);
   }
 
   /**

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1269,6 +1269,17 @@ module('Unit | Utility | changeset', function(hooks) {
     assert.equal(get(dummyChangeset, 'errors.length'), 1, 'should only have 1 error');
   });
 
+  test('#validate validates a multiple field immediately', async function(assert) {
+    dummyModel.setProperties({ name: 'J', password: false });
+    let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);
+
+    await dummyChangeset.validate('name', 'password');
+    assert.deepEqual(get(dummyChangeset, 'error.name'), { validation: 'too short', value: 'J' }, 'should validate immediately');
+    assert.deepEqual(get(dummyChangeset, 'error.password'), { validation: ['foo', 'bar'], value: false }, 'should validate immediately');
+    assert.deepEqual(get(dummyChangeset, 'changes'), [], 'should not set changes');
+    assert.equal(get(dummyChangeset, 'errors.length'), 2, 'should only have 2 error');
+  });
+
   test('#validate works correctly with changeset values', async function(assert) {
     dummyModel.setProperties({ name: undefined, password: false, async: true, passwordConfirmation: false, options: {}});
     let dummyChangeset = new Changeset(dummyModel, dummyValidator, dummyValidations);


### PR DESCRIPTION
## Changes proposed in this pull request
Allow `changeset.validate` to receive variable length keys
