### PR TITLE
Fix TS type for changeset.errors

### DIFF
--- a/addon/-private/validated-changeset.ts
+++ b/addon/-private/validated-changeset.ts
@@ -37,7 +37,7 @@ import {
   ValidatorMap
 } from 'ember-changeset/types';
 
-const { assign, keys } = Object;
+const { keys } = Object;
 const CONTENT = '_content';
 const CHANGES = '_changes';
 const ERRORS = '_errors';
@@ -157,13 +157,9 @@ export class BufferedChangeset implements IChangeset {
     }
 
     return keys(obj).map(key => {
-      let value = transform(obj[key]);
+      let { value, validation } = transform(obj[key]);
 
-      if (isObject(value)) {
-        return assign({ key }, value);
-      }
-
-      return { key, value };
+      return { key, value, validation };
     });
   }
 

--- a/addon/types/index.ts
+++ b/addon/types/index.ts
@@ -71,7 +71,7 @@ export interface ChangesetDef {
   _bareChanges: { [s: string]: any },
 
   changes: any, // { key: string; value: any; }[], //ComputedProperty<object[], object[]>,
-  errors: { key: string; value: any; }[], //ComputedProperty<object[], object[]>,
+  errors: { key: string; value: any; validation: ValidationErr | ValidationErr[] }[], //ComputedProperty<object[], object[]>,
   error: object,
   change: object,
   data: object,


### PR DESCRIPTION
Errors have the "validation" key, which has the error messages from validations.


