### PR TITLE
Add safeSet for Ember tracking context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ jobs:
       env: EMBER_TRY_SCENARIO=ember-3.13
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
+    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/addon/utils/merge-deep.ts
+++ b/addon/utils/merge-deep.ts
@@ -101,11 +101,11 @@ function mergeTargetAndSource(target: any, source: any, options: Options): any {
     } else {
       let next = source[key];
       if (next && next instanceof Change) {
-        return target[key] = next.value;
+        return options.safeSet(target, key, next.value);
       }
 
       // if just some normal leaf value, then set
-      return target[key] = next;
+      return options.safeSet(target, key, next);
     }
   });
 

--- a/addon/utils/merge-deep.ts
+++ b/addon/utils/merge-deep.ts
@@ -123,7 +123,7 @@ function mergeTargetAndSource(target: any, source: any, options: Options): any {
  */
 export default function mergeDeep(target: any, source: any, options: Options = { safeGet: undefined, safeSet: undefined }): object | [any] {
   options.safeGet = options.safeGet || function (obj: any, key: string): any { return obj[key] };
-  options.safeSet = options.safeSet;
+  options.safeSet = options.safeSet || function(obj: any, key: string, value: unknown): any { return obj[key] = value };
   let sourceIsArray = Array.isArray(source);
   let targetIsArray = Array.isArray(target);
   let sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -32,6 +32,7 @@ module.exports = async function() {
       },
       {
         name: 'ember-canary',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary')

--- a/tests/dummy/app/components/changeset-form.ts
+++ b/tests/dummy/app/components/changeset-form.ts
@@ -2,12 +2,13 @@ import Component from '@ember/component';
 import { action } from '@ember/object';
 import Changeset from 'ember-changeset'
 
-export default class ChangesetForm extends Component.extend() {
+export default class ChangesetForm extends Component {
   model = {
     email: 'something'
   }
 
   changeset = new Changeset(this.model)
+
   @action submitForm(changeset: any, event: any) {
     event.preventDefault()
     changeset.save()

--- a/tests/dummy/app/components/changeset-form.ts
+++ b/tests/dummy/app/components/changeset-form.ts
@@ -1,20 +1,13 @@
 import Component from '@ember/component';
-// @ts-ignore: Ignore import of compiled template
-/* import layout from '../templates/components/changeset-form'; */
-/* import { tracked } from '@glimmer/tracking'; */
 import { action } from '@ember/object';
 import Changeset from 'ember-changeset'
 
-export default class ChangesetForm extends Component.extend({
-  // anything which *must* be merged to prototype here
-}) {
+export default class ChangesetForm extends Component.extend() {
   model = {
     email: 'something'
   }
 
   changeset = new Changeset(this.model)
-  // normal class body definition here
-
   @action submitForm(changeset: any, event: any) {
     event.preventDefault()
     changeset.save()

--- a/tests/dummy/app/components/changeset-form.ts
+++ b/tests/dummy/app/components/changeset-form.ts
@@ -1,0 +1,22 @@
+import Component from '@ember/component';
+// @ts-ignore: Ignore import of compiled template
+/* import layout from '../templates/components/changeset-form'; */
+/* import { tracked } from '@glimmer/tracking'; */
+import { action } from '@ember/object';
+import Changeset from 'ember-changeset'
+
+export default class ChangesetForm extends Component.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  model = {
+    email: 'something'
+  }
+
+  changeset = new Changeset(this.model)
+  // normal class body definition here
+
+  @action submitForm(changeset: any, event: any) {
+    event.preventDefault()
+    changeset.save()
+  }
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,5 @@
-<h2 id="title">Hello world</h2>
+<h2 id="title">Basic Form</h2>
+
+<ChangesetForm />
 
 {{outlet}}

--- a/tests/dummy/app/templates/components/changeset-form.hbs
+++ b/tests/dummy/app/templates/components/changeset-form.hbs
@@ -1,15 +1,16 @@
-Changeset value: "{{this.changeset.email}}"
+<h2>Changeset value: <span data-test-changeset-email>{{this.changeset.email}}</span></h2>
 <br />
-Model value: "{{this.model.email}}"
+<h2>Model value: <span data-test-model-email>{{this.model.email}}</span></h2>
 
 <form
   {{on "submit" (fn this.submitForm this.changeset)}}
 >
   <input
+    data-test-email
     type="text"
     value={{this.changeset.email}}
     oninput={{action (changeset-set this.changeset "email") value="target.value"}}
   >
-  <button type="submit">Submit form 1</button>
+  <button data-test-submit type="submit">Submit form 1</button>
 
 </form>

--- a/tests/dummy/app/templates/components/changeset-form.hbs
+++ b/tests/dummy/app/templates/components/changeset-form.hbs
@@ -1,0 +1,15 @@
+Changeset value: "{{this.changeset.email}}"
+<br />
+Model value: "{{this.model.email}}"
+
+<form
+  {{on "submit" (fn this.submitForm this.changeset)}}
+>
+  <input
+    type="text"
+    value={{this.changeset.email}}
+    oninput={{action (changeset-set this.changeset "email") value="target.value"}}
+  >
+  <button type="submit">Submit form 1</button>
+
+</form>

--- a/tests/integration/components/changeset-form-test.js
+++ b/tests/integration/components/changeset-form-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, find, fillIn, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | changeset-form', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<ChangesetForm />`);
+    await fillIn('[data-test-email]', 'foo');
+    await click('[data-test-submit]');
+
+    assert.equal(find('[data-test-model-email]').textContent.trim(), 'foo', 'has email after submit');
+    assert.equal(find('[data-test-changeset-email]').textContent.trim(), 'foo', 'changeset has email after submit');
+  });
+});


### PR DESCRIPTION
close #394 

@josemarluedke 👋 Thank you for the issue!  I believe this is because we need to use `Ember.set`.  This PR makes it work.

One question is - what was the reason to track the model on the Component instance in your example?  At first I assumed this wasn't necessary.  Let me know your thoughts!