### PR TITLE
Add failing test for error keys

### DIFF
--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -146,12 +146,21 @@ module('Unit | Utility | changeset', function(hooks) {
     assert.deepEqual(dummyChangeset.get('change').name, 'a', 'should return nested change');
   });
 
-  test('can get nested values in the errors object', function(assert) {
-    let dummyChangeset = new Changeset(dummyModel, dummyValidator);
-    dummyChangeset.set('org.usa.ny', '');
 
-    let expectedErrors = [{ key: 'org.usa.ny', validation: 'must be present', value: '' }];
-    assert.deepEqual(dummyChangeset.get('errors'), expectedErrors, 'should return errors object for `org.usa.ny` key');
+  test("can get nested values in the errors object", function(assert) {
+    let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+    dummyChangeset.set("org.usa.ny", "");
+    dummyChangeset.set("name", "");
+
+    let expectedErrors = [
+      { key: "org.usa.ny", validation: "must be present", value: "" },
+      { key: "name", validation: "too short", value: "" }
+    ];
+    assert.deepEqual(
+      dummyChangeset.get("errors"),
+      expectedErrors,
+      "should return errors object for `org.usa.ny` key and `name` key"
+    );
   });
 
   /**


### PR DESCRIPTION
This adds a failing test after the changes in #399. 

<img width="538" alt="Screen Shot 2020-01-11 at 11 19 01 AM" src="https://user-images.githubusercontent.com/230476/72209526-2e840780-3464-11ea-992a-fb576a3c90ab.png">
