### PR TITLE
Fix a bug with unsafe properties

### DIFF
--- a/addon/utils/merge-deep.ts
+++ b/addon/utils/merge-deep.ts
@@ -67,14 +67,12 @@ function buildPathToValue(source: any, options: Options, kv: Record<string, any>
   Object.keys(source).forEach((key: string): void => {
     let possible = source[key];
     if (possible && possible.hasOwnProperty('value')) {
-      possibleKeys.push(key);
-      kv[possibleKeys.join('.')] = possible.value;
+      kv[[...possibleKeys, key].join('.')] = possible.value;
       return;
     }
 
     if (typeof possible === 'object') {
-      possibleKeys.push(key);
-      buildPathToValue(possible, options, kv, possibleKeys);
+      buildPathToValue(possible, options, kv, [...possibleKeys, key]);
     }
   });
 

--- a/tests/unit/utils/merge-deep-test.js
+++ b/tests/unit/utils/merge-deep-test.js
@@ -35,4 +35,32 @@ module('Unit | Utility | merge deep', () => {
 
     assert.deepEqual(value, { company: { employees: ['Jull', 'Olafur']} }, 'has right employees');
   });
+
+  test('it works with unsafe properties', async function(assert) {
+    class A {
+      _boo = 'bo';
+
+      get boo() {
+        return this._boo;
+      }
+      set boo(value) {
+        this._boo = value;
+      }
+
+      foo = { baz: 'ba' };
+    }
+
+    class B extends A {
+      other = 'Ivan';
+    }
+
+    const objA = new B();
+    const objB = { boo: new Change('doo'), foo: { baz: new Change('bar') } };
+
+    const value = mergeDeep(objA, objB, { safeGet: get, safeSet: set });
+
+    assert.equal(value.boo, 'doo', 'unsafe plain property is merged');
+    assert.equal(value.other, 'Ivan', 'safe property is not touched');
+    assert.deepEqual(value.foo, { baz: 'bar' }, 'unsafe object property is merged');
+  });
 });


### PR DESCRIPTION
possibleKeys were shared between the branches during the traverse.
Each node could push to it making it polluted for the next branch.
Source like: {a: {}, b: {c: {}}} could produce paths like:
['a', 'a.b.c'] instead of ['a', 'b.c'];