### PR TITLE
Bring back changeset-get for nested getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ On rollback, all changes are dropped and the underlying Object is left untouched
 ## Changeset template helpers
 `ember-changeset` overrides `set` and `get` in order to handle deeply nested setters.  `mut` is simply an alias for `Ember.set(changeset, ...)`, thus we provide a `changeset-set` template helper if you are dealing with nested setters.
 
-`changeset-get` is necessary for nested getters to easily retrieve leaf keys without error.  Ember's templating layer will ask us the first key it finds.  We keep track of the changes, but to also keep track of unchanged values and properly represent them in the template is difficult.
+`changeset-get` is necessary for nested getters to easily retrieve leaf keys without error.  Ember's templating layer will ask us for the first key it finds.  We keep track of the changes, but to also keep track of unchanged values and properly merge them in the changeset is difficult.
 
 ```hbs
 <form>

--- a/README.md
+++ b/README.md
@@ -125,14 +125,14 @@ On rollback, all changes are dropped and the underlying Object is left untouched
 ## Changeset template helpers
 `ember-changeset` overrides `set` and `get` in order to handle deeply nested setters.  `mut` is simply an alias for `Ember.set(changeset, ...)`, thus we provide a `changeset-set` template helper if you are dealing with nested setters.
 
-**Removed** in the 3.0.0 series was `changeset-get`. Unecessary for nested getters if on Ember >= 3.13.
+`changeset-get` is necessary for nested getters to easily retrieve leaf keys without error.  Ember's templating layer will ask us the first key it finds.  We keep track of the changes, but to also keep track of unchanged values and properly represent them in the template is difficult.
 
 ```hbs
 <form>
   <input
     id="first-name"
     type="text"
-    value={{get changeset "person.firstname"}}
+    value={{changeset-get changeset "person.firstName"}}
     onchange={{action (changeset-set changeset "person.firstName") value="target.value"}}>
 </form>
 ```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ On rollback, all changes are dropped and the underlying Object is left untouched
 ## Changeset template helpers
 `ember-changeset` overrides `set` and `get` in order to handle deeply nested setters.  `mut` is simply an alias for `Ember.set(changeset, ...)`, thus we provide a `changeset-set` template helper if you are dealing with nested setters.
 
-`changeset-get` is necessary for nested getters to easily retrieve leaf keys without error.  Ember's templating layer will ask us for the first key it finds.  We keep track of the changes, but to also keep track of unchanged values and properly merge them in the changeset is difficult.
+`changeset-get` is necessary for nested getters to easily retrieve leaf keys without error.  Ember's templating layer will ask us for the first key it comes across as it traverses down the object (`user.firstName`).  We keep track of the changes, but to also keep track of unchanged values and properly merge them in the changeset is difficult.  If you are only accessing keys in an object that is only one level deep, you do not need this helper.
 
 ```hbs
 <form>

--- a/addon/helpers/changeset-get.ts
+++ b/addon/helpers/changeset-get.ts
@@ -1,7 +1,8 @@
 import Helper from '@ember/component/helper';
+import { IChangeset } from 'ember-changeset/types';
 
 export default class ChangesetGet extends Helper.extend() {
-  compute() {
-    throw new Error('changeset-get is now removed as of 3.0.0-beta.1.  See `https://github.com/poteto/ember-changeset/issues/379`');
+  compute(this: ChangesetGet, [changeset, fieldPath]: [IChangeset, string]) {
+    return changeset.get(fieldPath);
   }
 }

--- a/tests/dummy/app/templates/components/changeset-form.hbs
+++ b/tests/dummy/app/templates/components/changeset-form.hbs
@@ -1,5 +1,5 @@
-<h2>Changeset Name: <span data-test-changeset-user-name>{{this.changeset.user.name}}</span></h2>
-<h2>Changeset Email: <span data-test-changeset-user-email>{{this.changeset.user.email}}</span></h2>
+<h2>Changeset Name: <span data-test-changeset-user-name>{{changeset-get this.changeset "user.name"}}</span></h2>
+<h2>Changeset Email: <span data-test-changeset-user-email>{{changeset-get this.changeset "user.email"}}</span></h2>
 <h2>Changeset cid: <span data-test-changeset-cid>{{this.changeset.cid}}</span></h2>
 <br />
 <h2>Model Email: <span data-test-model-user-name>{{this.model.user.name}}</span></h2>

--- a/tests/dummy/app/templates/components/changeset-form.hbs
+++ b/tests/dummy/app/templates/components/changeset-form.hbs
@@ -1,4 +1,6 @@
 <h2>Changeset cid: <span data-test-changeset-cid>{{this.changeset.cid}}</span></h2>
+<h2>Changeset Email: <span data-test-changeset-user-email>{{changeset-get this.changeset "user.email"}}</span></h2>
+<h2>Changeset Name: <span data-test-changeset-user-name>{{changeset-get this.changeset "user.name"}}</span></h2>
 <br />
 <h2>Model Email: <span data-test-model-user-name>{{this.model.user.name}}</span></h2>
 <h2>Model Email: <span data-test-model-user-email>{{this.model.user.email}}</span></h2>
@@ -19,7 +21,7 @@
   <input
     data-test-user-name
     type="text"
-    value={{changeset-get this.changeset "user.name"}}
+    value={{get this.changeset "user.name"}}
     oninput={{action (changeset-set this.changeset "user.name") value="target.value"}}
   >
 

--- a/tests/dummy/app/templates/components/changeset-form.hbs
+++ b/tests/dummy/app/templates/components/changeset-form.hbs
@@ -1,5 +1,3 @@
-<h2>Changeset Name: <span data-test-changeset-user-name>{{changeset-get this.changeset "user.name"}}</span></h2>
-<h2>Changeset Email: <span data-test-changeset-user-email>{{changeset-get this.changeset "user.email"}}</span></h2>
 <h2>Changeset cid: <span data-test-changeset-cid>{{this.changeset.cid}}</span></h2>
 <br />
 <h2>Model Email: <span data-test-model-user-name>{{this.model.user.name}}</span></h2>
@@ -21,7 +19,7 @@
   <input
     data-test-user-name
     type="text"
-    value={{this.changeset.user.name}}
+    value={{changeset-get this.changeset "user.name"}}
     oninput={{action (changeset-set this.changeset "user.name") value="target.value"}}
   >
 

--- a/tests/integration/components/changeset-form-test.js
+++ b/tests/integration/components/changeset-form-test.js
@@ -11,11 +11,20 @@ module('Integration | Component | changeset-form', function(hooks) {
     await fillIn('[data-test-user-email]', 'foo');
     await fillIn('[data-test-cid]', 2);
 
+    assert.equal(find('[data-test-cid]').value, '2', 'has cid input value');
+    assert.equal(find('[data-test-user-email]').value, 'foo', 'has email input value');
+    assert.equal(find('[data-test-user-name]').value, 'someone', 'has name input value');
+
     await click('[data-test-submit]');
 
     assert.equal(find('[data-test-model-cid]').textContent.trim(), '2', 'has cid after submit');
     assert.equal(find('[data-test-model-user-email]').textContent.trim(), 'foo', 'has email after submit');
+
     assert.equal(find('[data-test-changeset-user-email]').textContent.trim(), 'foo', 'changeset has email after submit');
+
+    assert.equal(find('[data-test-cid]').value, '2', 'still has cid input value');
+    assert.equal(find('[data-test-user-email]').value, 'foo', 'still has email input value');
+    assert.equal(find('[data-test-user-name]').value, 'someone', 'still has name input value');
 
     await fillIn('[data-test-user-name]', 'bar');
 
@@ -24,5 +33,9 @@ module('Integration | Component | changeset-form', function(hooks) {
     assert.equal(find('[data-test-model-user-email]').textContent.trim(), 'foo', 'has correct email even when changing related properties');
     assert.equal(find('[data-test-changeset-cid]').textContent.trim(), '2', 'has correct cid even when changing related properties');
     assert.equal(find('[data-test-model-cid]').textContent.trim(), '2', 'has correct cid even when changing related properties');
+
+    assert.equal(find('[data-test-cid]').value, '2', 'has cid input value');
+    assert.equal(find('[data-test-user-email]').value, 'foo', 'has email input value');
+    assert.equal(find('[data-test-user-name]').value, 'bar', 'has name input value');
   });
 });

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -287,7 +287,7 @@ module('Unit | Utility | changeset', function(hooks) {
     assert.equal(result, '', 'should proxy to change');
   });
 
-  test('#get returns change that is has undefined as value', async function(assert) {
+  test('#get returns change that has undefined as value', async function(assert) {
     set(dummyModel, 'name', 'Jim Bob');
     let dummyChangeset = new Changeset(dummyModel);
     set(dummyChangeset, 'name', undefined);
@@ -296,7 +296,7 @@ module('Unit | Utility | changeset', function(hooks) {
     assert.equal(result, undefined, 'should proxy to change');
   });
 
-  test('#get returns change that is has undefined as value', async function(assert) {
+  test('#get returns change that has array as sibling', async function(assert) {
     set(dummyModel, 'name', 'Bob');
     set(dummyModel, 'creds', ['burgers']);
     let dummyChangeset = new Changeset(dummyModel);


### PR DESCRIPTION
Ideally our templating layer asks for the leaf key.  However this is not the case.  If looking for `this.user.name`, `user` will be propagated to the template layer.  

By requiring `changeset-get` for nested properties, we could remove the logic in #404.  Although still thinking if this is a good idea or not.