### PR TITLE
Ensure key in obj works with dot separated

### DIFF
--- a/addon/-private/validated-changeset.ts
+++ b/addon/-private/validated-changeset.ts
@@ -15,6 +15,7 @@ import isPromise from 'ember-changeset/utils/is-promise';
 import mergeNested from 'ember-changeset/utils/merge-nested';
 import objectWithout from 'ember-changeset/utils/object-without';
 import take from 'ember-changeset/utils/take';
+import keyInObject from 'ember-changeset/utils/key-in-object';
 import mergeDeep from 'ember-changeset/utils/merge-deep';
 import setDeep from 'ember-changeset/utils/set-deep';
 import getDeep from 'ember-changeset/utils/get-deep';
@@ -209,16 +210,15 @@ export class BufferedChangeset implements IChangeset {
     let config: Config = this[OPTIONS];
     let skipValidate: boolean | undefined = config['skipValidate'];
 
+    let content: Content = this[CONTENT];
+    let oldValue = this.safeGet(content, key);
+
     if (skipValidate) {
-      let content: Content = this[CONTENT];
-      let oldValue = this.safeGet(content, key);
       this._setProperty({ key, value, oldValue });
       this._handleValidation(true, { key, value });
       return;
     }
 
-    let content: Content = this[CONTENT];
-    let oldValue: any = this.safeGet(content, key);
     this._setProperty({ key, value, oldValue });
     this._validateKey(key, value);
   }
@@ -709,7 +709,7 @@ export class BufferedChangeset implements IChangeset {
     if (!isEqual(oldValue, value)) {
       // @tracked
       this[CHANGES] = this.setDeep(changes, key, new Change(value));
-    } else if (key in changes) {
+    } else if (keyInObject(changes, key)) {
       // @tracked
       this[CHANGES] = this._deleteKey(CHANGES, key) as Changes;
     }
@@ -903,7 +903,7 @@ export class BufferedChangeset implements IChangeset {
     key: string,
     value: T
   ): void | Promise<ValidationResult | T | IErr<T>> | T | IErr<T> | ValidationResult {
-    if (this.hasOwnProperty(key) || key in this) {
+    if (this.hasOwnProperty(key) || keyInObject(this, key)) {
       this[key] = value;
       return;
     }

--- a/addon/utils/key-in-object.ts
+++ b/addon/utils/key-in-object.ts
@@ -1,0 +1,18 @@
+export default function keyInObject(obj: any, key: string = ''): boolean {
+  let [baseKey, ...keys] = key.split('.');
+
+  if (!baseKey || !(baseKey in obj)) {
+    return false;
+  }
+
+  if (!keys.length) {
+    return !!(obj[baseKey]);
+  }
+
+  let value = obj[baseKey];
+  if (value !== null && typeof value === 'object') {
+    return keyInObject(obj[baseKey], keys.join('.'));
+  }
+
+  return false;
+}

--- a/app/utils/key-in-object.js
+++ b/app/utils/key-in-object.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-changeset/utils/key-in-object';

--- a/tests/unit/utils/key-in-object-test.ts
+++ b/tests/unit/utils/key-in-object-test.ts
@@ -1,0 +1,31 @@
+import keyInObject from 'dummy/utils/key-in-object';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | key-in-object', function() {
+
+  test('it works with no key', function(assert) {
+    let result = keyInObject({});
+    assert.equal(result, false);
+  });
+
+  test('it works', function(assert) {
+    let result = keyInObject({ b: 'a'}, 'b');
+    assert.equal(result, true);
+
+    result = keyInObject({ b: 'a'}, 'a');
+    assert.equal(result, false);
+  });
+
+  test('it works with nested', function(assert) {
+    let result = keyInObject({ b: { a: 'c' } }, 'b.a');
+    assert.equal(result, true, 'nested key found');
+
+    result = keyInObject({ b: { a: 'c' } }, 'b.c');
+    assert.equal(result, false, 'nested key not found');
+  });
+
+  test('it works with nested key and only partially found', function(assert) {
+    let result = keyInObject({ b: true }, 'b.a');
+    assert.equal(result, false, 'partial match is false');
+  });
+});


### PR DESCRIPTION
red #415 

While investigating this, I noticed an issue with deleting keys in CHANGES if the key is dot separated `notifications.email`.

@josemarluedke 