### PR TITLE
Export Changeset class to allow overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See also the [plugins](#plugins) section for addons that extend `ember-changeset
 #### tl;dr
 
 ```js
-let changeset = new Changeset(user, validatorFn);
+let changeset = Changeset(user, validatorFn);
 user.get('firstName'); // "Michael"
 user.get('lastName'); // "Bolton"
 
@@ -53,7 +53,7 @@ user.get('lastName'); // "Bob"
 
 ## Usage
 
-First, create a new `Changeset` using the `changeset` helper or through JavaScript:
+First, create a new `Changeset` using the `changeset` helper or through JavaScript via a factory function:
 
 ```hbs
 {{! application/template.hbs}}
@@ -67,14 +67,14 @@ First, create a new `Changeset` using the `changeset` helper or through JavaScri
 
 ```js
 import Component from '@ember/component';
-import Changeset from 'ember-changeset';
+import { Changeset } from 'ember-changeset';
 
 export default FormComponent extends Component {
   init(...args) {
     super.init(...args)
 
     let validator = this.validate;
-    this.changeset = new Changeset(this.model, validator);
+    this.changeset = Changeset(this.model, validator);
   }
 }
 ```
@@ -142,7 +142,7 @@ On rollback, all changes are dropped and the underlying Object is left untouched
 The default behavior of `Changeset` is to automatically validate a field when it is set. Automatic validation can be disabled by passing `skipValidate` as an option when creating a changeset.
 
 ```js
-let changeset = new Changeset(model, validatorFn, validationMap, { skipValidate: true });
+let changeset = Changeset(model, validatorFn, validationMap, { skipValidate: true });
 ```
 
 ```hbs
@@ -325,7 +325,7 @@ Returns the Object that was wrapped in the changeset.
 
 ```js
 let user = { name: 'Bobby', age: 21, address: { zipCode: '10001' } };
-let changeset = new Changeset(user);
+let changeset = Changeset(user);
 
 changeset.get('data'); // user
 ```
@@ -516,8 +516,8 @@ The `save` method will also remove the internal list of changes if the `save` is
 Merges 2 changesets and returns a new changeset with the same underlying content and validator as the origin. Both changesets must point to the same underlying object. For example:
 
 ```js
-let changesetA = new Changeset(user, validatorFn);
-let changesetB = new Changeset(user, validatorFn);
+let changesetA = Changeset(user, validatorFn);
+let changesetB = Changeset(user, validatorFn);
 
 changesetA.set('firstName', 'Jim');
 changesetA.set('address.zipCode', '94016');
@@ -564,7 +564,7 @@ Rolls back unsaved changes for the specified property only. All other changes wi
 
 ```js
 // user = { firstName: "Jim", lastName: "Bob" };
-let changeset = new Changeset(user);
+let changeset = Changeset(user);
 changeset.set('firstName', 'Jimmy');
 changeset.set('lastName', 'Fallon');
 changeset.rollbackProperty('lastName'); // returns changeset
@@ -592,7 +592,7 @@ let validationMap = {
   'address.zipCode': validateLength({ is: 5 }),
 };
 
-let changeset = new Changeset(user, validatorFn, validationMap);
+let changeset = Changeset(user, validatorFn, validationMap);
 changeset.get('isValid'); // true
 
 // validate single field; returns Promise
@@ -668,7 +668,7 @@ Restores a snapshot of changes and errors to the changeset. This overrides exist
 
 ```js
 let user = { name: 'Adam', address: { country: 'United States' } };
-let changeset = new Changeset(user, validatorFn);
+let changeset = Changeset(user, validatorFn);
 
 changeset.set('name', 'Jim Bob');
 changeset.set('address.country', 'North Korea');
@@ -690,7 +690,7 @@ Unlike `Ecto.Changeset.cast`, `cast` will take an array of allowed keys and remo
 
 ```js
 let allowed = ['name', 'password', 'address.country'];
-let changeset = new Changeset(user, validatorFn);
+let changeset = Changeset(user, validatorFn);
 
 changeset.set('name', 'Jim Bob');
 changeset.set('address.country', 'United States');

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ export default class FormController extends Controller {
   @action
   validate({ key, newValue, oldValue, changes, content }) {
     // lookup a validator function on your favorite validation library
-    // should return a Boolean
+    // and return a Boolean
   }
 }
 ```

--- a/addon/helpers/changeset.ts
+++ b/addon/helpers/changeset.ts
@@ -1,11 +1,7 @@
 import { helper } from '@ember/component/helper';
-import { Changeset as ChangesetFactory } from 'ember-changeset';
-import {
-  IChangeset,
-  Config,
-  ValidatorAction,
-  ValidatorMap
-} from 'ember-changeset/types';
+import Changeset from 'ember-changeset';
+import { Config } from 'ember-changeset/types/config';
+import { ValidatorAction, ValidatorMap } from 'ember-changeset/types/validator-action';
 import lookupValidator from 'ember-changeset/utils/validator-lookup';
 import isChangeset from 'ember-changeset/utils/is-changeset';
 import isPromise from 'ember-changeset/utils/is-promise';
@@ -14,27 +10,26 @@ import isObject from 'ember-changeset/utils/is-object';
 export function changeset(
   [obj, validations]: [object | Promise<any>, ValidatorAction | ValidatorMap],
   options: Config = {}
-): IChangeset | Promise<IChangeset> {
-  const isIChangeset = (obj: unknown): obj is IChangeset => isChangeset(obj);
-  if (isIChangeset(obj)) {
+): Changeset | Promise<Changeset> {
+  if (isChangeset(obj)) {
     return obj;
   }
 
   if (isObject(validations)) {
     if (isPromise(obj)) {
       return (<Promise<any>>obj).then((resolved) =>
-        ChangesetFactory(resolved, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options)
+        new Changeset(resolved, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options)
       );
     }
 
-    return ChangesetFactory(obj, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options);
+    return new Changeset(obj, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options);
   }
 
   if (isPromise(obj)) {
-    return Promise.resolve(obj).then((resolved: any) => ChangesetFactory(resolved, <ValidatorAction>validations, {}, options));
+    return Promise.resolve(obj).then((resolved: any) => new Changeset(resolved, <ValidatorAction>validations, {}, options));
   }
 
-  return ChangesetFactory(obj, <ValidatorAction>validations, {}, options);
+  return new Changeset(obj, <ValidatorAction>validations, {}, options);
 }
 
 export default helper(changeset);

--- a/addon/helpers/changeset.ts
+++ b/addon/helpers/changeset.ts
@@ -1,7 +1,11 @@
 import { helper } from '@ember/component/helper';
-import Changeset from 'ember-changeset';
-import { Config } from 'ember-changeset/types/config';
-import { ValidatorAction, ValidatorMap } from 'ember-changeset/types/validator-action';
+import { Changeset as ChangesetFactory } from 'ember-changeset';
+import {
+  IChangeset,
+  Config,
+  ValidatorAction,
+  ValidatorMap
+} from 'ember-changeset/types';
 import lookupValidator from 'ember-changeset/utils/validator-lookup';
 import isChangeset from 'ember-changeset/utils/is-changeset';
 import isPromise from 'ember-changeset/utils/is-promise';
@@ -10,26 +14,27 @@ import isObject from 'ember-changeset/utils/is-object';
 export function changeset(
   [obj, validations]: [object | Promise<any>, ValidatorAction | ValidatorMap],
   options: Config = {}
-): Changeset | Promise<Changeset> {
-  if (isChangeset(obj)) {
+): IChangeset | Promise<IChangeset> {
+  const isIChangeset = (obj: unknown): obj is IChangeset => isChangeset(obj);
+  if (isIChangeset(obj)) {
     return obj;
   }
 
   if (isObject(validations)) {
     if (isPromise(obj)) {
       return (<Promise<any>>obj).then((resolved) =>
-        new Changeset(resolved, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options)
+        ChangesetFactory(resolved, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options)
       );
     }
 
-    return new Changeset(obj, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options);
+    return ChangesetFactory(obj, lookupValidator(<ValidatorMap>validations), <ValidatorMap>validations, options);
   }
 
   if (isPromise(obj)) {
-    return Promise.resolve(obj).then((resolved: any) => new Changeset(resolved, <ValidatorAction>validations, {}, options));
+    return Promise.resolve(obj).then((resolved: any) => ChangesetFactory(resolved, <ValidatorAction>validations, {}, options));
   }
 
-  return new Changeset(obj, <ValidatorAction>validations, {}, options);
+  return ChangesetFactory(obj, <ValidatorAction>validations, {}, options);
 }
 
 export default helper(changeset);

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -151,7 +151,7 @@ export function changeset(
     return new options.changeset(obj, validateFn, validationMap, options);
   }
 
-  const c = Changeset(obj, validateFn, validationMap, options);
+  const c = new EmberChangeset(obj, validateFn, validationMap, options);
   return c;
 }
 

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -183,6 +183,7 @@ export function Changeset(
 export default class ChangesetKlass {
   /**
    * Changeset factory
+   * TODO: deprecate in favor of factory function
    *
    * @class ChangesetKlass
    * @constructor

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -23,7 +23,7 @@ const ERRORS = '_errors';
 const CONTENT = '_content';
 const defaultValidatorFn = () => true;
 
-class EmberChangeset extends BufferedChangeset {
+export class EmberChangeset extends BufferedChangeset {
   @tracked '_changes': Changes;
   @tracked '_errors': Errors<any>;
   @tracked '_content': any;
@@ -147,8 +147,11 @@ export function changeset(
   assert('Underlying object for changeset is missing', Boolean(obj));
   assert('Array is not a valid type to pass as the first argument to `changeset`', !Array.isArray(obj));
 
-  const c = new EmberChangeset(obj, validateFn, validationMap, options);
+  if (options.changeset) {
+    return new options.changeset(obj, validateFn, validationMap, options);
+  }
 
+  const c = new EmberChangeset(obj, validateFn, validationMap, options);
   return c;
 }
 

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -155,11 +155,36 @@ export function changeset(
   return c;
 }
 
-export default class Changeset {
+/**
+ * Creates new changesets.
+ * @function Changeset
+ */
+export function Changeset(
+  obj: object,
+  validateFn: ValidatorAction = defaultValidatorFn,
+  validationMap: ValidatorMap = {},
+  options: Config = {}
+) {
+  const c: IChangeset = changeset(obj, validateFn, validationMap, options);
+
+  return new Proxy(c, {
+    get(targetBuffer, key/*, receiver*/) {
+      const res = targetBuffer.get(key.toString());
+      return res;
+    },
+
+    set(targetBuffer, key, value/*, receiver*/) {
+      targetBuffer.set(key.toString(), value);
+      return true;
+    }
+  });
+}
+
+export default class ChangesetKlass {
   /**
    * Changeset factory
    *
-   * @class ValidatedChangeset
+   * @class ChangesetKlass
    * @constructor
    */
   constructor(

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -151,7 +151,7 @@ export function changeset(
     return new options.changeset(obj, validateFn, validationMap, options);
   }
 
-  const c = new EmberChangeset(obj, validateFn, validationMap, options);
+  const c = Changeset(obj, validateFn, validationMap, options);
   return c;
 }
 
@@ -164,7 +164,7 @@ export function Changeset(
   validateFn: ValidatorAction = defaultValidatorFn,
   validationMap: ValidatorMap = {},
   options: Config = {}
-) {
+): IChangeset {
   const c: IChangeset = changeset(obj, validateFn, validationMap, options);
 
   return new Proxy(c, {

--- a/addon/types/config.ts
+++ b/addon/types/config.ts
@@ -1,3 +1,4 @@
 export type Config = {
   skipValidate?: boolean
+  changeset?: any
 };

--- a/tests/dummy/app/components/changeset-form.ts
+++ b/tests/dummy/app/components/changeset-form.ts
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
-import Changeset from 'ember-changeset'
+import { Changeset } from 'ember-changeset'
 
 export default class ChangesetForm extends Component {
   model = {
@@ -17,7 +17,7 @@ export default class ChangesetForm extends Component {
     }
   }
 
-  changeset = new Changeset(this.model)
+  changeset = Changeset(this.model)
 
   @action submitForm(changeset: any, event: any) {
     event.preventDefault()

--- a/tests/dummy/app/components/changeset-form.ts
+++ b/tests/dummy/app/components/changeset-form.ts
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
-import { Changeset } from 'ember-changeset'
+import Changeset from 'ember-changeset'
 
 export default class ChangesetForm extends Component {
   model = {
@@ -17,7 +17,7 @@ export default class ChangesetForm extends Component {
     }
   }
 
-  changeset = Changeset(this.model)
+  changeset = new Changeset(this.model)
 
   @action submitForm(changeset: any, event: any) {
     event.preventDefault()

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1,4 +1,4 @@
-import Changeset from 'ember-changeset';
+import Changeset, { EmberChangeset, Changeset as ChangesetFactory } from 'ember-changeset';
 import { settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
@@ -1865,5 +1865,32 @@ module('Unit | Utility | changeset', function(hooks) {
     c.validate('org.usa.ny')
       .then(() => c.set('org.usa.ny', 'should not fail'))
       .finally(done);
+  });
+
+  test('can call Changeset Factory function', async function(assert) {
+    set(dummyModel, 'org', {
+      usa: { ny: 'vaca' }
+    });
+    let dummyChangeset = ChangesetFactory(dummyModel, dummyValidator);
+    dummyChangeset.set('org.usa.ny', '');
+
+    assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+    dummyChangeset.set('org.usa.ny', 'vaca');
+    assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+    assert.notOk(get(dummyChangeset, 'isInvalid'), 'should be valid');
+  });
+
+  test('can call with extended Changeset', async function(assert) {
+    set(dummyModel, 'org', {
+      usa: { ny: 'vaca' }
+    });
+    let extended = class ExtendedChangeset extends EmberChangeset {}
+    let dummyChangeset = ChangesetFactory(dummyModel, dummyValidator, null, { changeset: extended });
+    dummyChangeset.set('org.usa.ny', '');
+
+    assert.ok(get(dummyChangeset, 'isInvalid'), 'should be invalid');
+    dummyChangeset.set('org.usa.ny', 'vaca');
+    assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
+    assert.notOk(get(dummyChangeset, 'isInvalid'), 'should be valid');
   });
 });


### PR DESCRIPTION
This PR would allow users to import the Changeset and extend from it.

```js
import { EmberChangeset } from 'ember-changeset
```

And use like so

```js
changeset(model, validationFn, validationMap, { changeset: ModifiedChangesetKlass })
```

Also the recommended way to generate new changesets is through a factory function instead of a class and the README has been updated.  I'm not sure why the original implementation had a class w/ constructor but the factory function seems better. No breaking changes though.  

```js
import { Changeset } from 'ember-changeset
```

close #174 #390 