### PR TITLE
prevent changelist properties from being proxyed to underlying object. 

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -187,7 +187,7 @@ export class EmberChangeset extends BufferedChangeset {
 
 
     // return getters/setters/methods on BufferedProxy instance
-    if (this[key]) {
+    if (typeof this[key] !== 'undefined') {
       return this[key];
     } else if (this[baseKey]) {
       const v = this[baseKey];

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1504,6 +1504,16 @@ module('Unit | Utility | changeset', function(hooks) {
     ]);
   });
 
+
+  test('#changeset properties do not proxy', async function(assert) {
+    dummyModel.setProperties({ name: undefined, password: false, async: true, isValid: 'not proxied'});
+    let dummyChangeset = Changeset(dummyModel, dummyValidator, dummyValidations);
+
+    dummyChangeset.set('name', 'Jim Bob');
+    await dummyChangeset.validate();
+    assert.equal(get(dummyChangeset, 'isValid'), false, 'should have 1 error');
+  });
+
   /**
    * #addError
    */


### PR DESCRIPTION
Quick fix for Issue #434
