### PR TITLE
Failing test: `changeset.error.${property}.validation` does not notify changes to observers

### DIFF
--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -109,14 +109,11 @@ module('Unit | Utility | changeset', function(hooks) {
       name() {}
     };
     let validatorFn = function() {
-      return [
-        'foo',
-        'bar',
-      ];
+      return 'foo';
     };
     let dummyChangeset = new Changeset({ name: null }, validatorFn, Validations);
     let emberObject = EmberObject.extend({
-      errors: computed('changeset.error.name.validation.[]', function() {
+      errors: computed('changeset.error.name.validation', function() {
         return this.get('changeset.error.name.validation');
       }),
     }).create({
@@ -126,8 +123,8 @@ module('Unit | Utility | changeset', function(hooks) {
     emberObject.errors;
 
     await dummyChangeset.validate();
-    assert.deepEqual(dummyChangeset.error.name.validation, ['foo', 'bar'], 'on changeset');
-    assert.deepEqual(emberObject.errors, ['foo', 'bar'], 'through computed property');
+    assert.deepEqual(dummyChangeset.error.name.validation, 'foo', 'on changeset');
+    assert.deepEqual(emberObject.errors, 'foo', 'through computed property');
   });
 
   /**

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -100,6 +100,20 @@ module('Unit | Utility | changeset', function(hooks) {
     assert.deepEqual(dummyChangeset.get('error.name'), expectedResult, 'should return error object for `name` key');
   });
 
+  test('can observe validation result of one property in error object', function(assert) {
+    let dummyChangeset = new Changeset(dummyModel, dummyValidator);
+    let emberObject = EmberObject.extend({
+      errorForName: reads('changeset.error.name.validation'),
+    }).create({
+      changeset: dummyChangeset
+    });
+
+    assert.equal(emberObject.errorForName, undefined);
+
+    dummyChangeset.set('name', 'a');
+    assert.equal(emberObject.errorForName, 'too short');
+  });
+
   /**
    * #change
    */


### PR DESCRIPTION
Ported the failing test from https://github.com/poteto/ember-changeset-validations/pull/229 as the bug seems to be present in this upstream library as well. For context please also see https://github.com/poteto/ember-changeset-validations/issues/226.