### PR TITLE
Add failing test for input updates in octane

### DIFF
--- a/tests/integration/components/changeset-test.js
+++ b/tests/integration/components/changeset-test.js
@@ -539,5 +539,31 @@ module('Integration | Helper | changeset', function(hooks) {
     assert.equal(find('h1').textContent.trim(), 'J B', 'should update observable value');
     assert.notOk(find('#error-paragraph'), 'should skip validation');
   });
+
+  test ('it handles updates to and from <input>', async function (assert) {
+    this.set('changeset', new Changeset({name: 'initial value'}));
+    this.set('fieldName', 'name');
+    this.set('handleChange', event => {
+      this.changeset.set(this.fieldName, event.target.value);
+    });
+    await render (hbs`
+        <input
+          name={{this.fieldName}}
+          value={{readonly (get this.changeset this.fieldName)}}
+          {{on 'input' (fn this.handleChange)}}
+        />
+      `);
+
+    assert.equal(find('input').value, 'initial value');
+
+    await fillIn('input', 'update from input', "initial value was set");
+    assert.equal(this.changeset.name, 'update from input', "updated changeset from input");
+
+    this.changeset.set('name', 'updated input from changeset.set');
+    assert.equal(find('input').value, 'updated input from changeset.set');
+
+    this.changeset.name = 'updated input form changeset.property='; // also fails
+    assert.equal(find('input').value, 'updated input form changeset.property=');
+  });
 });
 


### PR DESCRIPTION
While updating some components for octane/glimmer I found the bug illustrated in this test. Updates from changesets do not get reflected in bound inputs. It seems like internal properties on the changeset aren't being marked as `@tracked` internally? 

I'm not sure yet, but here's the failing test at least to start.