### PR TITLE
Changeset not dirty from hasMany change

### DIFF
--- a/tests/integration/main-test.js
+++ b/tests/integration/main-test.js
@@ -155,8 +155,13 @@ module('Integration | main', function(hooks) {
     let user = this.createUser(userType, true);
     let changeset = Changeset(user);
     let newDog = this.store.createRecord('dog', { breed: 'Münsterländer' });
+
+    assert.equal(changeset.isDirty, false);
+
     let dogs = changeset.get('dogs');
     dogs.pushObjects([newDog]);
+
+    assert.equal(changeset.isDirty, true);
 
     dogs = changeset.get('dogs').toArray();
     assert.equal(dogs[0].get('breed'), 'rough collie');


### PR DESCRIPTION
Hi there! This PR adds a test showing changeset isn’t dirty after pushing to a hasmany — not quite intended to actually be merged.

What I want to verify with this PR is:

 - is this intended behavior? 
   - if not, is there a path towards fixing it? anything I could look at?
   - if yes, what're some alternatives?

Happy to help as much as I can :) 
