### PR TITLE
Failing test case for validating computed property

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-auto-import": "^1.5.2",
     "@glimmer/tracking": "^1.0.0",
     "ember-cli-babel": "^7.19.0",
-    "validated-changeset": "~0.5.10"
+    "validated-changeset": "~0.5.11"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12777,10 +12777,10 @@ validate-npm-package-name@~2.2.2:
   dependencies:
     builtins "0.0.7"
 
-validated-changeset@~0.5.10:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.5.10.tgz#4fbf68f64c6d84cac6f03b531aaff6b5aa24a35b"
-  integrity sha512-xPu81ng9WH1ITMcoiS9qWtGW07d97nhQguDIEBIuFG9tDE/JJyZvzCOewuY1UsQ6CRoLngLE/asmnp3BnrGe6w==
+validated-changeset@~0.5.11:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.5.11.tgz#f6fe33af8320125d82f1b2f9599fad9188097c3f"
+  integrity sha512-ZGaaIHjGfb5yn4DbIxF0gTzGDyq0+hDJgAaQBSx8gLTUXnKlcN/wDlEhBcmRQMiNOS/oHQlN5At+0TNXIpcuWQ==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Not sure if it is supposed to work, but this PR illustrates the issue.

The use case is the following:
I want to be able to validate derived state, not the root state.
So, model contains a bunch of changes, but the condition of validity
is defined based on several changes.

With the regular approach when changes are applied to a model, I can
define a computed property (or a getter) and validate against it.

With the changeset approach, model's computed property won't be updated
because the model itself is not changed. So, the idea is to define a
computed property on the Changeset level. But it isn't even evaluated.

Illustrates #474 