### PR TITLE
Mark keys that were nullified with a change as Empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Some notable changes going from 2.x to 3.x
 - error.validation is a string if one validation and array if multiple validations.
 - Defining a validation for a nested key worked before with {'something.else': ValidationFunc} and now it only works when defining as an object: { something: { else: validationFunc } }.
 
+## [3.5.4](https://github.com/poteto/ember-changeset/tree/v3.5.4) (2020-06-04)
+[Full Changelog](https://github.com/poteto/ember-changeset/compare/v3.5.0...v3.5.4)
+
+- Add ability to validate derived state [#482](https://github.com/poteto/ember-changeset/pull/482)
 ## [3.5.0](https://github.com/poteto/ember-changeset/tree/v3.5.0) (2020-05-28)
 [Full Changelog](https://github.com/poteto/ember-changeset/compare/v3.4.0...v3.5.0)
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,7 @@
 import { assert } from '@ember/debug';
 import { BufferedChangeset } from 'validated-changeset';
 import mergeDeep from './utils/merge-deep';
+import isObject from './utils/is-object';
 import { notifyPropertyChange } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { get as safeGet, set as safeSet } from '@ember/object';
@@ -14,6 +15,8 @@ export class EmberChangeset extends BufferedChangeset {
   @tracked '_changes';
   @tracked '_errors';
   @tracked '_content';
+
+  isObject = isObject;
 
   // DO NOT override setDeep. Ember.set does not work wth empty hash and nested
   // key Ember.set({}, 'user.name', 'foo');

--- a/addon/utils/is-object.js
+++ b/addon/utils/is-object.js
@@ -1,0 +1,43 @@
+import ObjectProxy from '@ember/object/proxy';
+import ArrayProxy from '@ember/array/proxy';
+import { typeOf } from '@ember/utils';
+
+function isBelongsToRelationship(obj) {
+  if (!obj) {
+    return false;
+  }
+
+  if (obj.hasOwnProperty('content') &&
+      obj.hasOwnProperty('isFulfilled') &&
+      obj.hasOwnProperty('isRejected')) {
+    // Async belongsTo()
+    return true;
+  }
+
+  if ('isLoading' in obj &&
+      'isLoaded' in obj &&
+      'isNew' in obj &&
+      'hasDirtyAttributes' in obj) {
+    // Sync belongsTo()
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * This is used to indicate we dont want to break apart and iterate the object
+ * However, it does not indicate the ability to getDeep and setDeep.
+ *
+ * @method isObject
+ */
+export default function isObject(val) {
+  return val !== null &&
+    (typeof val === 'object' || typeOf(val) === 'instance') &&
+    !(val instanceof Date) &&
+    !Array.isArray(val) &&
+    !(val instanceof ObjectProxy) &&
+    !(val instanceof ArrayProxy) &&
+    !isBelongsToRelationship(val)
+}
+

--- a/addon/utils/is-object.js
+++ b/addon/utils/is-object.js
@@ -2,28 +2,28 @@ import ObjectProxy from '@ember/object/proxy';
 import ArrayProxy from '@ember/array/proxy';
 import { typeOf } from '@ember/utils';
 
-function isBelongsToRelationship(obj) {
-  if (!obj) {
-    return false;
-  }
+// function isBelongsToRelationship(obj) {
+//   if (!obj) {
+//     return false;
+//   }
 
-  if (obj.hasOwnProperty('content') &&
-      obj.hasOwnProperty('isFulfilled') &&
-      obj.hasOwnProperty('isRejected')) {
-    // Async belongsTo()
-    return true;
-  }
+//   if (obj.hasOwnProperty('content') &&
+//       obj.hasOwnProperty('isFulfilled') &&
+//       obj.hasOwnProperty('isRejected')) {
+//     // Async belongsTo()
+//     return true;
+//   }
 
-  if ('isLoading' in obj &&
-      'isLoaded' in obj &&
-      'isNew' in obj &&
-      'hasDirtyAttributes' in obj) {
-    // Sync belongsTo()
-    return true;
-  }
+//   if ('isLoading' in obj &&
+//       'isLoaded' in obj &&
+//       'isNew' in obj &&
+//       'hasDirtyAttributes' in obj) {
+//     // Sync belongsTo()
+//     return true;
+//   }
 
-  return false;
-}
+//   return false;
+// }
 
 /**
  * This is used to indicate we dont want to break apart and iterate the object
@@ -37,7 +37,6 @@ export default function isObject(val) {
     !(val instanceof Date) &&
     !Array.isArray(val) &&
     !(val instanceof ObjectProxy) &&
-    !(val instanceof ArrayProxy) &&
-    !isBelongsToRelationship(val)
+    !(val instanceof ArrayProxy)
 }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-auto-import": "^1.5.2",
     "@glimmer/tracking": "^1.0.0",
     "ember-cli-babel": "^7.19.0",
-    "validated-changeset": "~0.6.5"
+    "validated-changeset": "~0.6.6"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-auto-import": "^1.5.2",
     "@glimmer/tracking": "^1.0.0",
     "ember-cli-babel": "^7.19.0",
-    "validated-changeset": "~0.6.6"
+    "validated-changeset": "git+ssh://git@github.com:validated-changeset/validated-changeset#sn/overridable-is-object"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12777,10 +12777,9 @@ validate-npm-package-name@~2.2.2:
   dependencies:
     builtins "0.0.7"
 
-validated-changeset@~0.6.6:
+"validated-changeset@git+ssh://git@github.com:validated-changeset/validated-changeset#sn/overridable-is-object":
   version "0.6.6"
-  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.6.6.tgz#e6ab09874a800ab010e28c0f5b4611de9779bdcc"
-  integrity sha512-X6Wn6KrlOOx2CTkzySEOmrSFaDOsnkTPpsUwg43vSfJ+jEOUVVNh+Gn+pwgziIWaYBfuFV4mnkTdJFiEPfMhuA==
+  resolved "git+ssh://git@github.com:validated-changeset/validated-changeset#605a1a74eb2c7eee734a0d945a3c6ae353529c98"
 
 vary@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12777,10 +12777,10 @@ validate-npm-package-name@~2.2.2:
   dependencies:
     builtins "0.0.7"
 
-validated-changeset@~0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.6.5.tgz#04b04e6a1fe32e937e18ff99c56e26152097ad7e"
-  integrity sha512-kppw9aeCvcEYXAWvPVQBWkOFu4dI/pdgtXZ84P+RnuKBiuVZE7rmet7q2Y/Eih75BvIUmt/6qFA4SQR86H/9/A==
+validated-changeset@~0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.6.6.tgz#e6ab09874a800ab010e28c0f5b4611de9779bdcc"
+  integrity sha512-X6Wn6KrlOOx2CTkzySEOmrSFaDOsnkTPpsUwg43vSfJ+jEOUVVNh+Gn+pwgziIWaYBfuFV4mnkTdJFiEPfMhuA==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
So we can ensure they are returned as undefined to the user when asked (instead of the content value for a key which might not be undefined)

https://github.com/validated-changeset/validated-changeset/pull/66