### PR TITLE
Fix nested execute() merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The base library for this addon is [validated-changeset](https://github.com/vali
 
 The idea behind a changeset is simple: it represents a set of valid changes to be applied onto any Object (`Ember.Object`, `DS.Model`, POJOs, etc). Each change is tested against an optional validation, and if valid, the change is stored and applied when executed.
 
-Given Ember's Data Down, Actions Up (DDAU) approach, a changeset is more appropriate compared to implicit 2 way bindings. Other validation libraries only validate a property *after* it is set on an Object, which means that your Object can enter an invalid state.
+Assuming a Data Down, Actions Up (DDAU) approach, a changeset is more appropriate compared to implicit 2 way bindings. Other validation libraries only validate a property *after* it is set on an Object, which means that your Object can enter an invalid state.
 
 `ember-changeset` only allows valid changes to be set, so your Objects will never become invalid (assuming you have 100% validation coverage). Additionally, this addon is designed to be un-opinionated about your choice of form and/or validation library, so you can easily integrate it into an existing solution.
 

--- a/addon/utils/merge-deep.js
+++ b/addon/utils/merge-deep.js
@@ -15,18 +15,18 @@ function isSpecial(value) {
   return stringValue === '[object RegExp]' || stringValue === '[object Date]';
 }
 
-function getEnumerableOwnPropertySymbols(target) {
-  return Object.getOwnPropertySymbols
-    ? Object.getOwnPropertySymbols(target).filter(symbol => {
-      return Object.prototype.propertyIsEnumerable.call(target, symbol)
-    })
-    : [];
-}
+// Reconsider when enumerable symbols are removed - https://github.com/emberjs/ember.js/commit/ef0e277533b3eab01e58d68b79d7e37d8b11ee34
+// function getEnumerableOwnPropertySymbols(target) {
+//   return Object.getOwnPropertySymbols
+//     ? Object.getOwnPropertySymbols(target).filter(symbol => {
+//       return Object.prototype.propertyIsEnumerable.call(target, symbol)
+//     })
+//     : [];
+// }
 
 function getKeys(target) {
-  return Object.keys(target)
-    .concat(getEnumerableOwnPropertySymbols(target))
-    .filter(key => typeof key === 'string' || typeof key === 'number')
+  return Object.keys(target);
+    // .concat(getEnumerableOwnPropertySymbols(target))
 }
 
 function propertyIsOnObject(object, property) {

--- a/addon/utils/merge-deep.js
+++ b/addon/utils/merge-deep.js
@@ -1,4 +1,5 @@
 import { Change } from 'validated-changeset';
+import { normalizeObject } from 'validated-changeset';
 
 function isMergeableObject(value) {
   return isNonNullObject(value) && !isSpecial(value);
@@ -109,7 +110,7 @@ function mergeTargetAndSource(target, source, options) {
       }
 
       // if just some normal leaf value, then set
-      return options.safeSet(target, key, next);
+      return options.safeSet(target, key, normalizeObject(next));
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@glimmer/tracking": "^1.0.1",
     "ember-auto-import": "^1.5.2",
     "ember-cli-babel": "^7.19.0",
-    "validated-changeset": "~0.8.1"
+    "validated-changeset": "~0.8.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",
@@ -58,7 +58,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.18.0",
+    "ember-source": "~3.20.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^2.6.0",
     "ember-try": "^1.2.1",

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1074,6 +1074,32 @@ module('Unit | Utility | changeset', function(hooks) {
     assert.deepEqual(get(dummyModel, 'org'), expectedResult.org, 'should set value');
   });
 
+  test('execute returns correct object after setting value on empty initial object', async function(assert) {
+    assert.expect(2);
+
+    let c = Changeset({});
+
+    c.set('org.usa.ny', 'any value');
+
+    assert.deepEqual(c.execute().data, {
+      org: {
+        usa: {
+          ny: "any value"
+        }
+      }
+    });
+    c.set('org.usa.il', '2nd value');
+
+    assert.deepEqual(c.execute().data, {
+      org: {
+        usa: {
+          ny: "any value",
+          il: "2nd value"
+        }
+      }
+    });
+  });
+
 
   /**
    * #pendingChanges

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1075,13 +1075,18 @@ module('Unit | Utility | changeset', function(hooks) {
   });
 
   test('execute returns correct object after setting value on empty initial object', async function(assert) {
-    assert.expect(2);
-
     let c = Changeset({});
+
+    c.set('country', 'usa');
+
+    assert.deepEqual(c.execute().data, {
+      country: 'usa'
+    });
 
     c.set('org.usa.ny', 'any value');
 
     assert.deepEqual(c.execute().data, {
+      country: 'usa',
       org: {
         usa: {
           ny: "any value"
@@ -1091,6 +1096,7 @@ module('Unit | Utility | changeset', function(hooks) {
     c.set('org.usa.il', '2nd value');
 
     assert.deepEqual(c.execute().data, {
+      country: 'usa',
       org: {
         usa: {
           ny: "any value",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3068,6 +3068,23 @@ broccoli-concat@^3.7.4:
     lodash.uniq "^4.2.0"
     walk-sync "^0.3.2"
 
+broccoli-concat@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-4.2.4.tgz#78e359ddc540b999d815355163bf3cfb6bd67322"
+  integrity sha512-NgdBIE57r+U/AslBohQr0mCS7PopIWL8dihMI1CzqffQkisAgqWMuddjYmizqRBQlml7crBFaBeUnPDHhf4/RQ==
+  dependencies:
+    broccoli-debug "^0.6.5"
+    broccoli-kitchen-sink-helpers "^0.3.1"
+    broccoli-plugin "^4.0.2"
+    ensure-posix-path "^1.0.2"
+    fast-sourcemap-concat "^2.1.0"
+    find-index "^1.1.0"
+    fs-extra "^8.1.0"
+    fs-tree-diff "^2.0.1"
+    lodash.merge "^4.6.2"
+    lodash.omit "^4.1.0"
+    lodash.uniq "^4.2.0"
+
 broccoli-config-loader@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-config-loader/-/broccoli-config-loader-1.0.1.tgz#d10aaf8ebc0cb45c1da5baa82720e1d88d28c80a"
@@ -5140,7 +5157,7 @@ ember-cli-version-checker@^4.1.0:
     semver "^6.3.0"
     silent-error "^1.1.1"
 
-ember-cli-version-checker@^5.0.2:
+ember-cli-version-checker@^5.0.2, ember-cli-version-checker@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz#3185c526c14671609cbd22ab0d0925787fc84f3d"
   integrity sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==
@@ -5360,10 +5377,10 @@ ember-source-channel-url@^2.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.18.0:
-  version "3.18.1"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.18.1.tgz#64ef40261ef1094e529ef6baabd907e6171a51f7"
-  integrity sha512-hfBkU2w+R7zquHpdMI+HCCt51OiBA4vkVd/czm+Xr17+qkxswh748l/VQe0N0IJLhrWlbmeOI6gtrB+Hsk8QAg==
+ember-source@~3.20.0:
+  version "3.20.4"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.20.4.tgz#582545ae3b20de5ffd9f8b43c42c94815e592291"
+  integrity sha512-ycWlaq7W63S3Nh7pMRU4oXNirBB9MbNGDN6hUgs3/qc1gjOUVGfGv0p2NPVcKXgqWtbiqrWGqCbp1iTay2MUpA==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
@@ -5371,22 +5388,22 @@ ember-source@~3.18.0:
     "@ember/edition-utils" "^1.2.0"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
-    broccoli-concat "^3.7.4"
+    broccoli-concat "^4.2.4"
     broccoli-debug "^0.6.4"
     broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.2"
-    chalk "^3.0.0"
-    ember-cli-babel "^7.18.0"
+    broccoli-merge-trees "^4.2.0"
+    chalk "^4.0.0"
+    ember-cli-babel "^7.19.0"
     ember-cli-get-component-path-option "^1.0.0"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-version-checker "^3.1.3"
+    ember-cli-version-checker "^5.1.1"
     ember-router-generator "^2.0.0"
     inflection "^1.12.0"
-    jquery "^3.4.1"
-    resolve "^1.14.2"
+    jquery "^3.5.0"
+    resolve "^1.17.0"
     semver "^6.1.1"
     silent-error "^1.1.1"
 
@@ -6076,6 +6093,20 @@ fast-sourcemap-concat@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/fast-sourcemap-concat/-/fast-sourcemap-concat-1.4.0.tgz#122c330d4a2afaff16ad143bc9674b87cd76c8ad"
   integrity sha512-x90Wlx/2C83lfyg7h4oguTZN4MyaVfaiUSJQNpU+YEA0Odf9u659Opo44b0LfoVg9G/bOE++GdID/dkyja+XcA==
+  dependencies:
+    chalk "^2.0.0"
+    fs-extra "^5.0.0"
+    heimdalljs-logger "^0.1.9"
+    memory-streams "^0.1.3"
+    mkdirp "^0.5.0"
+    source-map "^0.4.2"
+    source-map-url "^0.3.0"
+    sourcemap-validator "^1.1.0"
+
+fast-sourcemap-concat@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-sourcemap-concat/-/fast-sourcemap-concat-2.1.0.tgz#12dd36bfc38c804093e4bd1de61dd6216f574211"
+  integrity sha512-L9uADEnnHOeF4U5Kc3gzEs3oFpNCFkiTJXvT+nKmR0zcFqHZJJbszWT7dv4t9558FJRGpCj8UxUpTgz2zwiIZA==
   dependencies:
     chalk "^2.0.0"
     fs-extra "^5.0.0"
@@ -7982,7 +8013,7 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jquery@^3.4.1:
+jquery@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
@@ -11246,7 +11277,7 @@ resolve@1.9.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -12980,10 +13011,10 @@ validate-npm-package-name@~2.2.2:
   dependencies:
     builtins "0.0.7"
 
-validated-changeset@~0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.8.1.tgz#2053dd758dcc380d1d44daebf5b1d542bcd7ac58"
-  integrity sha512-3gpfpgrYwe1gZx066ntAaEX4PYjHu1mahy/iiM1s7a7dAu0O2+xEiKl/EZPTIaSp7pIR4qk3mbj9zZYidaaK3Q==
+validated-changeset@~0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.8.2.tgz#6480fb3c4269095e160062df1825df6d303805e9"
+  integrity sha512-XEWjzRK53AM1mNwYFYnMG83HtJR5VjUQX9i7p7sIZsaeVa7tg9AfMjwXu7PtL7Fs9M3mwdUcngV6shgGnFNPvw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
close #530 #529 

Minor issue in ember-release.  As of this [commit](https://github.com/emberjs/ember.js/commit/ef0e277533b3eab01e58d68b79d7e37d8b11ee34), Ember Objects have enumerable symbols on create.  We had some "nice to have" code that ensured enumerable symbols were still allowed as keys Maybe in the future we can bring this back.