### PR TITLE
add test to demonstrate how the changeset properties are not notifying computed properties.

### DIFF
--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -8,9 +8,10 @@ import EmberObject, {
   get,
   set,
   setProperties,
+  computed
 } from '@ember/object';
 
-import { reads } from '@ember/object/computed';
+import { reads, empty, filterBy } from '@ember/object/computed';
 import ObjectProxy from '@ember/object/proxy';
 import { dasherize } from '@ember/string';
 import { isPresent } from '@ember/utils';
@@ -2299,5 +2300,32 @@ module('Unit | Utility | changeset', function(hooks) {
     dummyChangeset.set('org.usa.ny', 'vaca');
     assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
     assert.notOk(get(dummyChangeset, 'isInvalid'), 'should be valid');
+  });
+
+  test('changeset isDirty property notifies dependent computed properties', async function(assert) {
+    const Model = EmberObject.extend({
+
+      hasDirtyChangesets: empty('dirtyChangesets'),
+
+      dirtyChangesets: filterBy('changesets', 'isDirty', true),
+
+      changesets: computed(function() {
+        return [
+          Changeset(dummyModel, dummyValidator),
+          Changeset(dummyModel, dummyValidator)
+        ]
+      })
+    });
+
+    let model = Model.create();
+
+    assert.ok(get(model, 'hasDirtyChangesets'), 'no dirty changesets');
+    
+    let changesets = get(model, 'changesets');
+
+    set(changesets[0], 'name', 'new name');
+
+    assert.notOk(get(model, 'hasDirtyChangesets'), 'has dirty changesets');
+
   });
 });

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -2307,25 +2307,46 @@ module('Unit | Utility | changeset', function(hooks) {
 
       hasDirtyChangesets: empty('dirtyChangesets'),
 
-      dirtyChangesets: filterBy('changesets', 'isDirty', true),
+      filterDirtyChangesets: filterBy('changesets', 'isDirty', true),
+
+      dirtyChangesets: computed('changesets.@each.isDirty', function() {
+        let cs = this.get('changesets');
+        return cs.filter((c) => { return c.get('isDirty')});
+      }),
 
       changesets: computed(function() {
         return [
           Changeset(dummyModel, dummyValidator),
           Changeset(dummyModel, dummyValidator)
         ]
+      }),
+
+      changeset: computed(function() {
+        return Changeset(dummyModel, dummyValidator)
+      }),
+
+      isChangesetDirty: computed('changeset.isDirty', function() {
+        return this.get('changeset.isDirty');
       })
+
     });
 
     let model = Model.create();
 
     assert.ok(get(model, 'hasDirtyChangesets'), 'no dirty changesets');
+    assert.equal(model.dirtyChangesets.length, 0, 'has 0 dirty changesets');
+    assert.equal(get(model, 'isChangesetDirty'), false, 'changeset not dirty')
     
     let changesets = get(model, 'changesets');
 
     set(changesets[0], 'name', 'new name');
-
+    assert.equal(model.dirtyChangesets.length, 1, 'has one dirty changesets');
     assert.notOk(get(model, 'hasDirtyChangesets'), 'has dirty changesets');
 
+    let changeset = get(model, 'changeset');
+    set(changeset, 'name', 'other new name');
+    assert.equal(get(model, 'isChangesetDirty'), true, 'changeset is dirty')
   });
+
+  
 });

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -11,7 +11,7 @@ import EmberObject, {
   computed
 } from '@ember/object';
 
-import { reads, empty, filterBy } from '@ember/object/computed';
+import { reads } from '@ember/object/computed';
 import ObjectProxy from '@ember/object/proxy';
 import { dasherize } from '@ember/string';
 import { isPresent } from '@ember/utils';
@@ -2303,33 +2303,32 @@ module('Unit | Utility | changeset', function(hooks) {
   });
 
   test('changeset isDirty property notifies dependent computed properties', async function(assert) {
-    const Model = EmberObject.extend({
+  
+    class Model extends EmberObject {
+      // single
+      @computed
+      get changeset() {
+        return Changeset(dummyModel, dummyValidator);
+      }
 
-      hasDirtyChangesets: empty('dirtyChangesets'),
+      get isChangesetDirty() {
+        return this.changeset.isDirty;
+      }
 
-      filterDirtyChangesets: filterBy('changesets', 'isDirty', true),
+      // double
+      @computed
+      get changesets() {
+        return [Changeset(dummyModel, dummyValidator), Changeset(dummyModel, dummyValidator)];
+      }
 
-      dirtyChangesets: computed('changesets.@each.isDirty', function() {
-        let cs = this.get('changesets');
-        return cs.filter((c) => { return c.get('isDirty')});
-      }),
+      get hasDirtyChangesets() {
+        return this.dirtyChangesets.length > 0;
+      }
 
-      changesets: computed(function() {
-        return [
-          Changeset(dummyModel, dummyValidator),
-          Changeset(dummyModel, dummyValidator)
-        ]
-      }),
-
-      changeset: computed(function() {
-        return Changeset(dummyModel, dummyValidator)
-      }),
-
-      isChangesetDirty: computed('changeset.isDirty', function() {
-        return this.get('changeset.isDirty');
-      })
-
-    });
+      get dirtyChangesets() {
+        return this.changesets.filter((c) => c.isDirty);
+      }
+    }
 
     let model = Model.create();
 

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -2348,5 +2348,30 @@ module('Unit | Utility | changeset', function(hooks) {
     assert.equal(get(model, 'isChangesetDirty'), true, 'changeset is dirty')
   });
 
+
+  test('changeset tracked properties should work with es6 class getters', async function(assert) {
+    class Model {
+      get changeset() {
+        this.__changeset__ = this.__changeset__ || Changeset(dummyModel, dummyValidator);
+        
+        return this.__changeset__;
+      }
+
+      get isChangesetDirty() {
+        return this.changeset.isDirty;
+      }
+    }
+
+    let model = new Model;
+    
+    assert.equal(model.isChangesetDirty, false, 'changeset is not dirty');
+    
+    model.changeset.set('name', 'other new name')
+    
+    assert.equal(model.isChangesetDirty, true, 'changeset is dirty')
+  
+  });
+
+
   
 });


### PR DESCRIPTION
ember-changeset should be compatible with computed properties and macros.   
