### PR TITLE
failing test for wrong error handling

### DIFF
--- a/tests/dummy/app/models/profile.js
+++ b/tests/dummy/app/models/profile.js
@@ -3,6 +3,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default Model.extend({
   firstName: attr('string', { defaultValue: 'Bob' }),
   lastName: attr('string', { defaultValue: 'Ross' }),
+  startDate: attr('date'),
 
   pet: belongsTo('dog'),
 });

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -2409,4 +2409,23 @@ module('Unit | Utility | changeset', function (hooks) {
     assert.ok(get(dummyChangeset, 'isValid'), 'should be valid');
     assert.notOk(get(dummyChangeset, 'isInvalid'), 'should be valid');
   });
+
+  test('calling save then setting a date from null to something and rejecting does return the right error', async function (assert) {
+    const dummyModel = this.owner.lookup('service:store').createRecord('profile', { startDate: null });
+
+    dummyModel.save = () => {
+      return Promise.reject({ errors: [{ detail: 'bad backend error' }] });
+    };
+
+    let dummyChangeset = Changeset(dummyModel, () => {});
+    dummyChangeset.startDate = new Date();
+
+    try {
+      await dummyChangeset.save();
+      assert.ok(false, 'save should fail if the underlaying save fails');
+    } catch (err) {
+      console.log('err', err);
+      assert.equal(err?.errors?.[0]?.detail, 'bad backend error', 'Wrong error: ' + err.message);
+    }
+  });
 });


### PR DESCRIPTION
when changing a date on a ember-date model from null to something
and then rejecting the Promise during `changeset.save()` it will not
return the right error but instead `can't convert null to object`.

I'm not able to reproduce this on a non `ember-data` object or on anything except a `@attr('date')`.