### PR TITLE
Support for validator class in validation arrays

### DIFF
--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -2071,6 +2071,30 @@ module('Unit | Utility | changeset', function (hooks) {
     assert.deepEqual(dummyChangeset.get('errors.length'), 1);
   });
 
+  test('#validate works with validator class in array', async function (assert) {
+    class PersonalValidator {
+      _validate(value) {
+        if (value === null) {
+          return 'oh no';
+        }
+      }
+      validate(key, newValue) {
+        return this._validate(newValue);
+      }
+    }
+    const validatorMap = {
+      name: [new PersonalValidator()],
+    };
+
+    let dummyChangeset = Changeset(dummyModel, lookupValidator(validatorMap), validatorMap);
+    dummyChangeset.name = null;
+
+    await dummyChangeset.validate();
+
+    assert.deepEqual(dummyChangeset.get('error.name.validation'), 'oh no');
+    assert.deepEqual(dummyChangeset.get('errors.length'), 1);
+  });
+
   /**
    * #addError
    */


### PR DESCRIPTION
## Changes proposed in this pull request

Class validators are great! 
However, they do not work when there is more than 1 validation for a given attribute.

It would be perfect if this kind of validator map could be supported:

```
const validatorMap = {
  name: [
    validatePresence(true),
    validateLength({ min: 4 })
    new PersonalValidator()
  ],
};
```