### PR TITLE
#unexecute to revert changes to underlying Object from #save

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-  pull_request:
+    branches:
+      - master
+  pull_request: {}
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Some notable changes going from 2.x to 3.x
 - error.validation is a string if one validation and array if multiple validations.
 - Defining a validation for a nested key worked before with {'something.else': ValidationFunc} and now it only works when defining as an object: { something: { else: validationFunc } }.
 
+## [3.10.4](https://github.com/poteto/ember-changeset/tree/v3.10.4) (2020-12-05)
+
+- #unexecute to revert changes to underlying Object from #save
+
 ## [3.10.3](https://github.com/poteto/ember-changeset/tree/v3.10.3) (2020-12-05)
 
 - Support multiple validators with class validators

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ import { ValidationResult, ValidatorMapFunc, ValidatorAction } from 'ember-chang
   - [`set`](#set)
   - [`prepare`](#prepare)
   - [`execute`](#execute)
+  - [`unexecute`](#unexecute)
   - [`save`](#save)
   - [`merge`](#merge)
   - [`rollback`](#rollback)
@@ -574,6 +575,21 @@ changeset.execute(); // returns changeset
 ```
 
 Note that executing the changeset will not remove the internal list of changes - instead, you should do so explicitly with `rollback` or `save` if that is desired.
+
+**[⬆️ back to top](#api)**
+
+#### `unexecute`
+
+Undo changes made to underlying Object for changeset. This is often useful if you want to remove changes from underlying Object if `save` fails.
+
+```js
+changeset
+  .save()
+  .catch(() => {
+    // save applies changes to the underlying Object via this.execute(). This may be undesired for your use case.
+    dummyChangeset.unexecute();
+  })
+```
 
 **[⬆️ back to top](#api)**
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@glimmer/tracking": "^1.0.1",
     "ember-auto-import": "^1.5.2",
     "ember-cli-babel": "^7.19.0",
-    "validated-changeset": "~0.10.3"
+    "validated-changeset": "~0.10.4"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1386,7 +1386,7 @@ module('Unit | Utility | changeset', function (hooks) {
       await dummyChangeset.save();
       assert.ok(false, 'WAT?!');
     } catch (error) {
-      dummyModel.unexecute();
+      dummyChangeset.unexecute();
       assert.equal(error.message, 'some ember data error');
     } finally {
       assert.equal(dummyModel.name, undefined, 'old name');
@@ -1410,7 +1410,7 @@ module('Unit | Utility | changeset', function (hooks) {
       await dummyChangeset.save();
       assert.ok(false, 'WAT?!');
     } catch (error) {
-      dummyModel.unexecute();
+      dummyChangeset.unexecute();
       assert.equal(error.message, 'some ember data error');
     } finally {
       assert.equal(dummyModel.name, 'original', 'old name');

--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -1386,6 +1386,7 @@ module('Unit | Utility | changeset', function (hooks) {
       await dummyChangeset.save();
       assert.ok(false, 'WAT?!');
     } catch (error) {
+      dummyModel.unexecute();
       assert.equal(error.message, 'some ember data error');
     } finally {
       assert.equal(dummyModel.name, undefined, 'old name');
@@ -1409,6 +1410,7 @@ module('Unit | Utility | changeset', function (hooks) {
       await dummyChangeset.save();
       assert.ok(false, 'WAT?!');
     } catch (error) {
+      dummyModel.unexecute();
       assert.equal(error.message, 'some ember data error');
     } finally {
       assert.equal(dummyModel.name, 'original', 'old name');

--- a/yarn.lock
+++ b/yarn.lock
@@ -13497,10 +13497,10 @@ validate-npm-package-name@~2.2.2:
   dependencies:
     builtins "0.0.7"
 
-validated-changeset@~0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.10.3.tgz#5f1280bdf6f6dd9cfecd404362c5154067ee21c8"
-  integrity sha512-qTvbPVtHO7j6ZZ14UxmzlZPgcNnaruFbaZnHwvNPwNYqWDH3Xkj3Fe1h20Bb/XwOFrqAOjc/iXs4OY3mMEcySg==
+validated-changeset@~0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.10.4.tgz#dcb3961f4e974eeb9430804f657b6f8eae84d5dd"
+  integrity sha512-05opaR2iE5XohmARGnMM04lx7xIQDiT3wxkvAQrT7Ix7EhmAHSWkFZbigoQ6iSLyERAaUw5IL593a5rUWkyFQg==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
close #354

https://github.com/validated-changeset/validated-changeset/pull/95

In order to access model.errors, we need to persist those changes on the underlying model. As a result, unexecute is opt in now instead of by default.