### PR TITLE
create reproduction test

### DIFF
--- a/tests/integration/helpers/changeset-get-test.js
+++ b/tests/integration/helpers/changeset-get-test.js
@@ -16,7 +16,7 @@ module('Integration | Helper | changeset-get', function (hooks) {
         last: 'Loblaw',
       },
       value: {
-        first: '<value>'
+        first: '<value>',
       },
       email: 'bob@lob.law',
       url: 'http://bobloblawslawblog.com',


### PR DESCRIPTION
Noticed this issue, but I think the problem is in validated-changeset, so I'm going to try a repro PR there as well.

The gist:
 - if a property has a key of `value`, and nested data changes, that change is not present in the `changes` array. if the key  is literally anything else and it works, which is cool -- I think I can fix this :)
 
 
 validated-changeset PR: https://github.com/validated-changeset/validated-changeset/pull/97