### PR TITLE
 Internal: Upgrade ember-template-lint to v3.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2960,6 +2960,54 @@
         }
       }
     },
+    "@ember-template-lint/todo-utils": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@ember-template-lint/todo-utils/-/todo-utils-10.0.0.tgz",
+      "integrity": "sha512-US8VKnetBOl8KfKz+rXGsosz6rIETNwSz2F2frM8hIoJfF/d6ME1Iz1K7tPYZEE6SoKqZFlBs5XZPSmzRnabjA==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "^7.2.13",
+        "fs-extra": "^9.1.0",
+        "slash": "^3.0.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
     "@ember/edition-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.2.0.tgz",
@@ -4088,9 +4136,9 @@
       "integrity": "sha1-/S0rVakCnGs3psk16MiHGucN+gc="
     },
     "@glimmer/global-context": {
-      "version": "0.62.5",
-      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.62.5.tgz",
-      "integrity": "sha512-bE8v/d/DBVXYJXsRYbeuuboC4UgpONq82ZleGHRNps/YKVD6Xfx3frCyvKq5CMxNtqf3TZIN80TNNPm2qb1t0A==",
+      "version": "0.65.4",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.65.4.tgz",
+      "integrity": "sha512-RSYCPG/uVR5XCDcPREBclncU7R0zkjACbADP+n3FWAH1TfWbXRMDIkvO/ZlwHkjHoCZf6tIM6p5S/MoFzfJEJA==",
       "dev": true,
       "requires": {
         "@glimmer/env": "^0.1.7"
@@ -4139,34 +4187,34 @@
       }
     },
     "@glimmer/syntax": {
-      "version": "0.62.5",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.62.5.tgz",
-      "integrity": "sha512-4e1KP3bAkTQIHcwjSjRsRvuzw6t1AMOU6zT1zo4g4QtwivKFG1pYmMTXmuLo/F25hRK4McdwST251AC/gc6w7Q==",
+      "version": "0.65.4",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.65.4.tgz",
+      "integrity": "sha512-y+/C3e8w96efk3a/Z5If9o4ztKJwrr8RtDpbhV2J8X+DUsn5ic2N3IIdlThbt/Zn6tkP1K3dY6uaFUx3pGTvVQ==",
       "dev": true,
       "requires": {
-        "@glimmer/interfaces": "0.62.5",
-        "@glimmer/util": "0.62.5",
+        "@glimmer/interfaces": "0.65.4",
+        "@glimmer/util": "0.65.4",
         "@handlebars/parser": "^1.1.0",
         "simple-html-tokenizer": "^0.5.10"
       },
       "dependencies": {
         "@glimmer/interfaces": {
-          "version": "0.62.5",
-          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.62.5.tgz",
-          "integrity": "sha512-DLCLY/S228ftSHlH+tXYBJhRr2J5TLzgyTKIIFKUJ7dKYdOT/6uVJX+Bk9/nldrwy5bVk2h5pkBoKyvw8xC93w==",
+          "version": "0.65.4",
+          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.65.4.tgz",
+          "integrity": "sha512-R0kby79tGNKZOojVJa/7y0JH9Eq4SV+L1s6GcZy30QUZ1g1AAGS5XwCIXc9Sc09coGcv//q+6NLeSw7nlx1y4A==",
           "dev": true,
           "requires": {
             "@simple-dom/interface": "^1.4.0"
           }
         },
         "@glimmer/util": {
-          "version": "0.62.5",
-          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.62.5.tgz",
-          "integrity": "sha512-V3OJYmM3jdmds4rxTfNx4g/xAD6hbVHrBJNaqNFbHUs8SPS5e1JVsN+x3YbDRbojRrH8gN67JFUfFoDqi7ppRg==",
+          "version": "0.65.4",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.65.4.tgz",
+          "integrity": "sha512-aofe+rdBhkREKP2GZta6jy1UcbRRMfWx7M18zxGxspPoeD08NscD04Kx+WiOKXmC1TcrfITr8jvqMfrKrMzYWQ==",
           "dev": true,
           "requires": {
             "@glimmer/env": "0.1.7",
-            "@glimmer/interfaces": "0.62.5",
+            "@glimmer/interfaces": "0.65.4",
             "@simple-dom/interface": "^1.4.0"
           }
         }
@@ -4510,6 +4558,16 @@
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
       "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==",
       "dev": true
+    },
+    "@types/eslint": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
+      "integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
     },
     "@types/estree": {
       "version": "0.0.50",
@@ -6237,6 +6295,49 @@
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "blank-object": {
@@ -8841,6 +8942,12 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
+      "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -11392,21 +11499,26 @@
       }
     },
     "ember-template-lint": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-2.14.0.tgz",
-      "integrity": "sha512-psRhYfw894mp6tF2Vv9gBbpHJwKz2dyEEwsL/zX1ksWGo7vQ4vAqrqPuLtCi/NPpoFnTr2VaCCK7xvef+fZ3MA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-3.10.0.tgz",
+      "integrity": "sha512-QP6gN9FwZbK+ypDr5PLXeKMPuAvKwfOWpIoqVD6DB660evnKE+rXfAdNga3CqSC7mDekpgJoLuxVQUw9oLcnjQ==",
       "dev": true,
       "requires": {
-        "chalk": "^4.0.0",
-        "ember-template-recast": "^4.2.0",
+        "@ember-template-lint/todo-utils": "^10.0.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.2.0",
+        "date-fns": "^2.25.0",
+        "ember-template-recast": "^5.0.3",
         "find-up": "^5.0.0",
+        "fuse.js": "^6.4.6",
         "get-stdin": "^8.0.0",
-        "globby": "^11.0.1",
-        "is-glob": "^4.0.1",
-        "micromatch": "^4.0.2",
-        "resolve": "^1.17.0",
-        "v8-compile-cache": "^2.1.1",
-        "yargs": "^16.0.3"
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.4",
+        "requireindex": "^1.2.0",
+        "resolve": "^1.20.0",
+        "v8-compile-cache": "^2.3.0",
+        "yargs": "^16.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11428,14 +11540,20 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "ci-info": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+          "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+          "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
@@ -11478,9 +11596,9 @@
           "dev": true
         },
         "globby": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -11489,6 +11607,15 @@
             "ignore": "^5.1.4",
             "merge2": "^1.3.0",
             "slash": "^3.0.0"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
@@ -11546,6 +11673,16 @@
           "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
           "dev": true
         },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
         "to-regex-range": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -11558,65 +11695,65 @@
       }
     },
     "ember-template-recast": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-4.3.0.tgz",
-      "integrity": "sha512-8sh2IqGZmiZzaFtwH99WK2dYpsa6pywPbqPHZfEIsY+SjtIDzVuE+fhS9d0grIWpraXyv/gPTnzSqrJq9e2xNA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-5.0.3.tgz",
+      "integrity": "sha512-qsJYQhf29Dk6QMfviXhUPE+byMOs6iRQxUDHgkj8yqjeppvjHaFG96hZi/NAXJTm/M7o3PpfF5YlmeaKtI9UeQ==",
       "dev": true,
       "requires": {
-        "@glimmer/reference": "^0.62.4",
-        "@glimmer/syntax": "^0.62.4",
-        "@glimmer/validator": "^0.62.4",
+        "@glimmer/reference": "^0.65.0",
+        "@glimmer/syntax": "^0.65.0",
+        "@glimmer/validator": "^0.65.0",
         "async-promise-queue": "^1.0.5",
         "colors": "^1.4.0",
-        "commander": "^6.2.0",
-        "globby": "^11.0.1",
-        "ora": "^5.1.0",
+        "commander": "^6.2.1",
+        "globby": "^11.0.3",
+        "ora": "^5.4.0",
         "slash": "^3.0.0",
         "tmp": "^0.2.1",
-        "workerpool": "^6.0.3"
+        "workerpool": "^6.1.4"
       },
       "dependencies": {
         "@glimmer/interfaces": {
-          "version": "0.62.5",
-          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.62.5.tgz",
-          "integrity": "sha512-DLCLY/S228ftSHlH+tXYBJhRr2J5TLzgyTKIIFKUJ7dKYdOT/6uVJX+Bk9/nldrwy5bVk2h5pkBoKyvw8xC93w==",
+          "version": "0.65.4",
+          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.65.4.tgz",
+          "integrity": "sha512-R0kby79tGNKZOojVJa/7y0JH9Eq4SV+L1s6GcZy30QUZ1g1AAGS5XwCIXc9Sc09coGcv//q+6NLeSw7nlx1y4A==",
           "dev": true,
           "requires": {
             "@simple-dom/interface": "^1.4.0"
           }
         },
         "@glimmer/reference": {
-          "version": "0.62.5",
-          "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.62.5.tgz",
-          "integrity": "sha512-d9T5WpKzU+T22MWrnkFaN1IM60TBQbeR6C43x1Cto4QvQfDAh3EImnLfETr8CUyz9WK+jc+IyWKQrpQdgMI+4Q==",
+          "version": "0.65.4",
+          "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.65.4.tgz",
+          "integrity": "sha512-yuRVE4qyqrlCndDMrHKDWUbDmGDCjPzsFtlTmxxnhDMJAdQsnr2cRLITHvQRDm1tXfigVvyKnomeuYhRRbBqYQ==",
           "dev": true,
           "requires": {
             "@glimmer/env": "^0.1.7",
-            "@glimmer/global-context": "0.62.5",
-            "@glimmer/interfaces": "0.62.5",
-            "@glimmer/util": "0.62.5",
-            "@glimmer/validator": "0.62.5"
+            "@glimmer/global-context": "0.65.4",
+            "@glimmer/interfaces": "0.65.4",
+            "@glimmer/util": "0.65.4",
+            "@glimmer/validator": "0.65.4"
           }
         },
         "@glimmer/util": {
-          "version": "0.62.5",
-          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.62.5.tgz",
-          "integrity": "sha512-V3OJYmM3jdmds4rxTfNx4g/xAD6hbVHrBJNaqNFbHUs8SPS5e1JVsN+x3YbDRbojRrH8gN67JFUfFoDqi7ppRg==",
+          "version": "0.65.4",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.65.4.tgz",
+          "integrity": "sha512-aofe+rdBhkREKP2GZta6jy1UcbRRMfWx7M18zxGxspPoeD08NscD04Kx+WiOKXmC1TcrfITr8jvqMfrKrMzYWQ==",
           "dev": true,
           "requires": {
             "@glimmer/env": "0.1.7",
-            "@glimmer/interfaces": "0.62.5",
+            "@glimmer/interfaces": "0.65.4",
             "@simple-dom/interface": "^1.4.0"
           }
         },
         "@glimmer/validator": {
-          "version": "0.62.5",
-          "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.62.5.tgz",
-          "integrity": "sha512-9+4QO3xH18etOJh8RJEh05R+g1/m4Qwta0bg0Go+m/yeYuGKH5v89DOe9PUWYcEQqug+TQSBJbspQJ4zMF6J3Q==",
+          "version": "0.65.4",
+          "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.65.4.tgz",
+          "integrity": "sha512-0YUjAyo45DF5JkQxdv5kHn96nMNhvZiEwsAD4Jme0kk5Q9MQcPOUtN76pQAS4f+C6GdF9DeUr2yGXZLFMmb+LA==",
           "dev": true,
           "requires": {
             "@glimmer/env": "^0.1.7",
-            "@glimmer/global-context": "0.62.5"
+            "@glimmer/global-context": "0.65.4"
           }
         },
         "ansi-styles": {
@@ -11628,31 +11765,10 @@
             "color-convert": "^2.0.1"
           }
         },
-        "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -11687,9 +11803,9 @@
           "dev": true
         },
         "globby": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -11727,17 +11843,6 @@
             "wcwidth": "^1.0.1"
           }
         },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -11745,15 +11850,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
           }
         },
         "tmp": {
@@ -13585,6 +13681,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "fuse.js": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.6.tgz",
+      "integrity": "sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw==",
       "dev": true
     },
     "gensync": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-resolver": "^8.0.0",
     "ember-source": "~3.24.0",
     "ember-source-channel-url": "^2.0.1",
-    "ember-template-lint": "^2.6.0",
+    "ember-template-lint": "^3.10.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.1.0",
     "eslint-plugin-ember": "^10.5.7",

--- a/tests/dummy/app/templates/components/changeset-form.hbs
+++ b/tests/dummy/app/templates/components/changeset-form.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable require-input-label --}}
 <h2>Changeset isPristine · {{this.changeset.isPristine}}</h2>
 <h2>Changeset cid: <span data-test-changeset-cid>{{this.changeset.cid}}</span></h2>
 <h2>Changeset Email: <span data-test-changeset-user-email>{{changeset-get this.changeset "user.email"}}</span></h2>


### PR DESCRIPTION
This is prerequisite to re-enable CI for Ember v4