### PR TITLE
Internal: Upgrade ember-qunit to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3037,269 +3037,117 @@
       }
     },
     "@ember/test-helpers": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-1.7.3.tgz",
-      "integrity": "sha512-0NwxM9rtl/vD/Zqv8cHefLxojL3l2xuRs6pEppff/Fe39ybXz5H7hm5ZvnpRO/lpSsIeX7tivht9ko6/V+sShw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-2.5.0.tgz",
+      "integrity": "sha512-7zDhA8KzU42R9J5+SrWncMA7C/v15e7JM9wfE2woktyR4AlVBP47qiphbJ8EhhWzE12wioY7cb5/Qw+RwgGEiQ==",
       "dev": true,
       "requires": {
+        "@ember/test-waiters": "^3.0.0",
         "broccoli-debug": "^0.6.5",
-        "broccoli-funnel": "^2.0.2",
-        "ember-assign-polyfill": "^2.6.0",
-        "ember-cli-babel": "^7.26.2",
-        "ember-cli-htmlbars-inline-precompile": "^2.1.0",
-        "ember-test-waiters": "^1.1.1"
+        "broccoli-funnel": "^3.0.8",
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1",
+        "ember-destroyable-polyfill": "^2.0.3"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+        "broccoli-funnel": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "array-equal": "^1.0.0",
+            "broccoli-plugin": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "walk-sync": "^2.0.2"
           }
         },
-        "@babel/helper-function-name": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-          "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+        "broccoli-plugin": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.14.5",
-            "@babel/template": "^7.14.5",
-            "@babel/types": "^7.14.5"
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-output-wrapper": "^3.2.5",
+            "fs-merger": "^3.2.1",
+            "promise-map-series": "^0.3.0",
+            "quick-temp": "^0.1.8",
+            "rimraf": "^3.0.2",
+            "symlink-or-copy": "^1.3.1"
           }
-        },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
-          "integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.14.5"
-          }
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-          "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.14.5"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
-          "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.14.5",
-            "@babel/helper-replace-supers": "^7.14.5",
-            "@babel/helper-simple-access": "^7.14.5",
-            "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.14.5",
-            "@babel/types": "^7.14.5"
-          }
-        },
-        "@babel/helper-optimise-call-expression": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-          "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.14.5"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
-          "dev": true
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-          "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.14.5",
-            "@babel/helper-optimise-call-expression": "^7.14.5",
-            "@babel/traverse": "^7.14.5",
-            "@babel/types": "^7.14.5"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-          "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.14.5"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-          "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
-          "dev": true
-        },
-        "@babel/plugin-proposal-class-properties": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
-          "integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.14.5",
-            "@babel/helper-plugin-utils": "^7.14.5"
-          }
-        },
-        "@babel/plugin-transform-modules-amd": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.5.tgz",
-          "integrity": "sha512-3lpOU8Vxmp3roC4vzFpSdEpGUWSMsHFreTWOMMLzel2gNGfHE5UWIh/LN6ghHs2xurUp4jRFYMUIZhuFbody1g==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-transforms": "^7.14.5",
-            "@babel/helper-plugin-utils": "^7.14.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3"
-          }
-        },
-        "@babel/runtime": {
-          "version": "7.12.18",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
-          "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@babel/template": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-          "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.14.5",
-            "@babel/parser": "^7.14.5",
-            "@babel/types": "^7.14.5"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
-          "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.14.5",
-            "@babel/generator": "^7.14.5",
-            "@babel/helper-function-name": "^7.14.5",
-            "@babel/helper-hoist-variables": "^7.14.5",
-            "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/parser": "^7.14.5",
-            "@babel/types": "^7.14.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz",
-          "integrity": "sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "broccoli-source": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
-          "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
-          "dev": true
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
         },
-        "ember-cli-babel": {
-          "version": "7.26.6",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz",
-          "integrity": "sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==",
+        "promise-map-series": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
-            "@babel/core": "^7.12.0",
-            "@babel/helper-compilation-targets": "^7.12.0",
-            "@babel/plugin-proposal-class-properties": "^7.13.0",
-            "@babel/plugin-proposal-decorators": "^7.13.5",
-            "@babel/plugin-transform-modules-amd": "^7.13.0",
-            "@babel/plugin-transform-runtime": "^7.13.9",
-            "@babel/plugin-transform-typescript": "^7.13.0",
-            "@babel/polyfill": "^7.11.5",
-            "@babel/preset-env": "^7.12.0",
-            "@babel/runtime": "7.12.18",
-            "amd-name-resolver": "^1.3.1",
-            "babel-plugin-debug-macros": "^0.3.4",
-            "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-            "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
-            "babel-plugin-module-resolver": "^3.2.0",
-            "broccoli-babel-transpiler": "^7.8.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.2",
-            "broccoli-source": "^2.1.2",
-            "clone": "^2.1.2",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^4.1.0",
-            "ensure-posix-path": "^1.0.2",
-            "fixturify-project": "^1.10.0",
-            "resolve-package-path": "^3.1.0",
-            "rimraf": "^3.0.1",
-            "semver": "^5.5.0"
+            "glob": "^7.1.3"
           }
         },
-        "ember-cli-version-checker": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
-          "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
           "dev": true,
           "requires": {
-            "resolve-package-path": "^2.0.0",
-            "semver": "^6.3.0",
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
+        }
+      }
+    },
+    "@ember/test-waiters": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ember/test-waiters/-/test-waiters-3.0.0.tgz",
+      "integrity": "sha512-z6+gIlq/rXLKroWv2wxAoiiLtgSOGQFCw6nUufERausV+jLnA7CYbWwzEo5R7XaOejSDpgA5d6haXIBsD5j0oQ==",
+      "dev": true,
+      "requires": {
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-version-checker": "^5.1.2",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
             "silent-error": "^1.1.1"
-          },
-          "dependencies": {
-            "resolve-package-path": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
-              "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-              "dev": true,
-              "requires": {
-                "path-root": "^0.1.1",
-                "resolve": "^1.13.1"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
           }
         },
         "resolve-package-path": {
@@ -3312,13 +3160,13 @@
             "resolve": "^1.17.0"
           }
         },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -9120,28 +8968,6 @@
         }
       }
     },
-    "ember-assign-polyfill": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/ember-assign-polyfill/-/ember-assign-polyfill-2.7.2.tgz",
-      "integrity": "sha512-hDSaKIZyFS0WRQsWzxUgO6pJPFfmcpfdM7CbGoMgYGriYbvkKn+k8zTXSKpTFVGehhSmsLE9YPqisQ9QpPisfA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.20.5",
-        "ember-cli-version-checker": "^2.0.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        }
-      }
-    },
     "ember-auto-import": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-1.11.3.tgz",
@@ -10189,37 +10015,6 @@
         }
       }
     },
-    "ember-cli-htmlbars-inline-precompile": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-2.1.0.tgz",
-      "integrity": "sha512-BylIHduwQkncPhnj0ZyorBuljXbTzLgRo6kuHf1W+IHFxThFl2xG+r87BVwsqx4Mn9MTgW9SE0XWjwBJcSWd6Q==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-htmlbars-inline-precompile": "^1.0.0",
-        "ember-cli-version-checker": "^2.1.2",
-        "hash-for-dep": "^1.2.3",
-        "heimdalljs-logger": "^0.1.9",
-        "silent-error": "^1.1.0"
-      },
-      "dependencies": {
-        "babel-plugin-htmlbars-inline-precompile": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz",
-          "integrity": "sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==",
-          "dev": true
-        },
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        }
-      }
-    },
     "ember-cli-inject-live-reload": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-2.0.2.tgz",
@@ -10305,135 +10100,12 @@
       }
     },
     "ember-cli-test-loader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz",
-      "integrity": "sha512-mlSXX9SciIRwGkFTX6XGyJYp4ry6oCFZRxh5jJ7VH8UXLTNx2ZACtDTwaWtNhYrWXgKyiDUvmD8enD56aePWRA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-3.0.0.tgz",
+      "integrity": "sha512-wfFRBrfO9gaKScYcdQxTfklx9yp1lWK6zv1rZRpkas9z2SHyJojF7NOQRWQgSB3ypm7vfpiF8VsFFVVr7VBzAQ==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^6.8.1"
-      },
-      "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "babel-plugin-ember-modules-api-polyfill": {
-          "version": "2.13.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
-          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
-          "dev": true,
-          "requires": {
-            "ember-rfc176-data": "^0.3.13"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
-          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^6.26.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.0.0",
-            "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^4.8.2",
-            "workerpool": "^2.3.0"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "merge-trees": "^1.0.1"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "fs-tree-diff": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-          "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-          "dev": true,
-          "requires": {
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "merge-trees": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
-          "requires": {
-            "can-symlink": "^1.0.0",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1"
-          }
-        }
+        "ember-cli-babel": "^7.13.2"
       }
     },
     "ember-cli-typescript": {
@@ -10696,6 +10368,58 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "ember-destroyable-polyfill": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz",
+      "integrity": "sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.22.1",
+        "ember-cli-version-checker": "^5.1.1",
+        "ember-compatibility-helpers": "^1.2.1"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -11050,18 +10774,98 @@
       }
     },
     "ember-qunit": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-4.6.0.tgz",
-      "integrity": "sha512-i5VOGn0RP8XH+5qkYDOZshbqAvO6lHgF65D0gz8vRx4DszCIvJMJO+bbftBTfYMxp6rqG85etAA6pfNxE0DqsQ==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-5.1.5.tgz",
+      "integrity": "sha512-2cFA4oMygh43RtVcMaBrr086Tpdhgbn3fVZ2awLkzF/rnSN0D0PSRpd7hAD7OdBPerC/ZYRwzVyGXLoW/Zes4A==",
       "dev": true,
       "requires": {
-        "@ember/test-helpers": "^1.7.1",
-        "broccoli-funnel": "^2.0.2",
+        "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^3.0.2",
-        "common-tags": "^1.4.0",
-        "ember-cli-babel": "^7.12.0",
-        "ember-cli-test-loader": "^2.2.0",
-        "qunit": "^2.9.3"
+        "common-tags": "^1.8.0",
+        "ember-auto-import": "^1.11.3",
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-test-loader": "^3.0.0",
+        "resolve-package-path": "^3.1.0",
+        "silent-error": "^1.1.1",
+        "validate-peer-dependencies": "^1.2.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "broccoli-plugin": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "walk-sync": "^2.0.2"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-output-wrapper": "^3.2.5",
+            "fs-merger": "^3.2.1",
+            "promise-map-series": "^0.3.0",
+            "quick-temp": "^0.1.8",
+            "rimraf": "^3.0.2",
+            "symlink-or-copy": "^1.3.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "promise-map-series": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+          "dev": true
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
+        }
       }
     },
     "ember-resolver": {
@@ -11761,24 +11565,6 @@
           "requires": {
             "rimraf": "^3.0.0"
           }
-        }
-      }
-    },
-    "ember-test-waiters": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ember-test-waiters/-/ember-test-waiters-1.2.0.tgz",
-      "integrity": "sha512-aEw7YuutLuJT4NUuPTNiGFwgTYl23ThqmBxSkfFimQAn+keWjAftykk3dlFELuhsJhYW/S8YoVjN0bSAQRLNtw==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.11.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
         }
       }
     },
@@ -16754,9 +16540,9 @@
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
     },
     "node-watch": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.1.tgz",
-      "integrity": "sha512-UWblPYuZYrkCQCW5PxAwYSxaELNBLUckrTBBk8xr1/bUgyOkYYTsUcV4e3ytcazFEOyiRyiUrsG37pu6I0I05g==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.2.tgz",
+      "integrity": "sha512-g53VjSARRv1JdST0LZRIg8RiuLr1TaBbVPsVvxh0/0Ymvi0xYUjDuoqQQAWtHJQUXhiShowPT/aXKNeHBcyQsw==",
       "dev": true
     },
     "nopt": {
@@ -17920,21 +17706,150 @@
       }
     },
     "qunit": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.16.0.tgz",
-      "integrity": "sha512-88x9t+rRMbB6IrCIUZvYU4pJy7NiBEv7SX8jD4LZAsIj+dV+kwGnFStOmPNvqa6HM96VZMD8CIIFKH2+3qvluA==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.17.2.tgz",
+      "integrity": "sha512-17isVvuOmALzsPjiV7wFg/6O5vJYXBrQZPwocfQSSh0I/rXvfX7bKMFJ4GMVW3U4P8r2mBeUy8EAngti4QD2Vw==",
       "dev": true,
       "requires": {
-        "commander": "7.1.0",
-        "node-watch": "0.7.1",
-        "tiny-glob": "0.2.8"
+        "commander": "7.2.0",
+        "node-watch": "0.7.2",
+        "tiny-glob": "0.2.9"
       },
       "dependencies": {
         "commander": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
-          "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
+        }
+      }
+    },
+    "qunit-dom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/qunit-dom/-/qunit-dom-2.0.0.tgz",
+      "integrity": "sha512-mElzLN99wYPOGekahqRA+mq7NcThXY9c+/tDkgJmT7W5LeZAFNyITr2rFKNnCbWLIhuLdFw88kCBMrJSfyBYpA==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "^3.0.3",
+        "broccoli-merge-trees": "^4.2.0",
+        "ember-cli-babel": "^7.23.0",
+        "ember-cli-version-checker": "^5.1.1"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "broccoli-plugin": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "walk-sync": "^2.0.2"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+          "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^4.0.2",
+            "merge-trees": "^2.0.0"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-output-wrapper": "^3.2.5",
+            "fs-merger": "^3.2.1",
+            "promise-map-series": "^0.3.0",
+            "quick-temp": "^0.1.8",
+            "rimraf": "^3.0.2",
+            "symlink-or-copy": "^1.3.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "promise-map-series": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+          "dev": true
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
         }
       }
     },
@@ -20742,9 +20657,9 @@
       }
     },
     "tiny-glob": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.8.tgz",
-      "integrity": "sha512-vkQP7qOslq63XRX9kMswlby99kyO5OvKptw7AMwBVMjXEI7Tb61eoI5DydyEMOseyGS5anDN1VPoVxEvH01q8w==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
       "dev": true,
       "requires": {
         "globalyzer": "0.1.0",
@@ -21310,6 +21225,46 @@
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
+      }
+    },
+    "validate-peer-dependencies": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/validate-peer-dependencies/-/validate-peer-dependencies-1.2.0.tgz",
+      "integrity": "sha512-nd2HUpKc6RWblPZQ2GDuI65sxJ2n/UqZwSBVtj64xlWjMx0m7ZB2m9b2JS3v1f+n9VWH/dd1CMhkHfP6pIdckA==",
+      "dev": true,
+      "requires": {
+        "resolve-package-path": "^3.1.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "validated-changeset": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",
+    "@ember/test-helpers": "^2.5.0",
     "@embroider/test-setup": "^0.41.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
@@ -58,7 +59,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^4.6.0",
+    "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.0",
     "ember-source": "~3.24.0",
     "ember-source-channel-url": "^2.0.1",
@@ -73,6 +74,8 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
+    "qunit": "^2.17.2",
+    "qunit-dom": "^2.0.0",
     "release-it": "^12.4.3",
     "release-it-lerna-changelog": "^1.0.3"
   },

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,7 +21,14 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="/testem.js" integrity=""></script>
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
+    <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>

--- a/tests/integration/components/changeset-form-test.js
+++ b/tests/integration/components/changeset-form-test.js
@@ -19,10 +19,6 @@ module('Integration | Component | changeset-form', function (hooks) {
 
     assert.true(find('[data-test-submit]').disabled, 'button disabled due to invalid email');
 
-    // submit - disabled until fill in proper email
-    await click('[data-test-submit]');
-
-    assert.true(find('[data-test-submit]').disabled, 'button still disabled after email');
     assert.strictEqual(
       find('[data-test-model-user-email]').textContent.trim(),
       'something',

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,8 +1,12 @@
-import Application from '../app';
-import config from '../config/environment';
+import Application from 'dummy/app';
+import config from 'dummy/config/environment';
+import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
+import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 
 setApplication(Application.create(config.APP));
+
+setup(QUnit.assert);
 
 start();


### PR DESCRIPTION
Just an internal clean up.
Aligns with the latest Ember CLI addon blueprint and modernizes addon setup (*I would guess* `ember-qunit@5` will become hard requirement at some point).