### PR TITLE
instanceof test

### DIFF
--- a/tests/unit/changeset-test.js
+++ b/tests/unit/changeset-test.js
@@ -2754,4 +2754,13 @@ module('Unit | Utility | changeset', function (hooks) {
     changeset.unexecute();
     assert.ok(true); // we just want no error until here
   });
+
+  test('instanceof checks on custom classes work`', async function (assert) {
+    class Foo {}
+    let model = EmberObject.create({ foo: new Foo() });
+    let dummyChangeset = Changeset(model);
+
+    assert.ok(dummyChangeset.foo.content instanceof Foo, 'content property is an instance');
+    assert.ok(dummyChangeset.foo instanceof Foo, 'proxy itself is an instance');
+  });
 });


### PR DESCRIPTION
This is for now just a failing test, and I'm not even sure this is an error of this repo.
The thing is, I'm not even sure this is a real problem and where this must be fixed.

However I'm very confident this is the error described in #629. I encountered the same Problem with a `Temporal`, which basically completely breaks. Utilizing `.content` works, however this is not nice.

The current behaviour is:

```js

    class Foo {}
    let model = EmberObject.create({ foo: new Foo() });
    let dummyChangeset = Changeset(model);

    // this *does* work!
    assert.ok(dummyChangeset.foo.content instanceof Foo, 'content property is an instance');
    
    // this *does not* work!
    assert.ok(dummyChangeset.foo instanceof Foo, 'proxy itself is an instance');
```